### PR TITLE
Bump filelock to 3.20.3 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ colorama==0.4.6 ; python_version >= "3.12" and python_version < "4.0" and (sys_p
 confection==0.1.5 ; python_version >= "3.12" and python_version < "4.0"
 cryptography==45.0.7 ; python_version >= "3.12" and python_version < "4.0"
 cymem==2.0.11 ; python_version >= "3.12" and python_version < "4.0"
-filelock==3.20.0 ; python_version >= "3.12" and python_version < "4.0"
+filelock==3.20.3 ; python_version >= "3.12" and python_version < "4.0"
 flashtext==2.7 ; python_version >= "3.12" and python_version < "4.0"
 flask==3.0.3 ; python_version >= "3.12" and python_version < "4.0"
 h11==0.16.0 ; python_version >= "3.12" and python_version < "4.0"


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `filelock` `3.20.0` → `3.20.3`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** filelock Time-of-Check-Time-of-Use (TOCTOU) Symlink Vulnerability in SoftFileLock CVE-2025-68146, CVE-2026-22701

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `2bdd16ceceedfb75` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"2bdd16ceceedfb75","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->