### PR TITLE
Bump mitmproxy to 12.2.2 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ mitmproxy-linux==0.12.8 ; python_version >= "3.12" and python_version < "4.0" an
 mitmproxy-macos==0.12.8 ; python_version >= "3.12" and python_version < "4.0" and sys_platform == "darwin"
 mitmproxy-rs==0.12.8 ; python_version >= "3.12" and python_version < "4.0"
 mitmproxy-windows==0.12.8 ; python_version >= "3.12" and python_version < "4.0" and os_name == "nt"
-mitmproxy==12.2.1 ; python_version >= "3.12" and python_version < "4.0"
+mitmproxy==12.2.2 ; python_version >= "3.12" and python_version < "4.0"
 msgpack==1.0.8 ; python_version >= "3.12" and python_version < "4.0"
 murmurhash==1.0.12 ; python_version >= "3.12" and python_version < "4.0"
 numpy==1.26.4 ; python_version >= "3.12" and python_version < "4.0"


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `mitmproxy` `12.2.1` → `12.2.2`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** mitmproxy has an LDAP Injection CVE-2026-40606

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `92e26e1ab4674f3e` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"92e26e1ab4674f3e","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->