### PR TITLE
Bump pyasn1 to 0.6.3 (high)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ presidio-anonymizer==2.2.352 ; python_version >= "3.12" and python_version < "4.
 prometheus-client==0.19.0 ; python_version >= "3.12" and python_version < "4.0"
 publicsuffix2==2.20191221 ; python_version >= "3.12" and python_version < "4.0"
 pyasn1-modules==0.4.2 ; python_version >= "3.12" and python_version < "4.0"
-pyasn1==0.6.1 ; python_version >= "3.12" and python_version < "4.0"
+pyasn1==0.6.3 ; python_version >= "3.12" and python_version < "4.0"
 pybreaker==1.4.1 ; python_version >= "3.12" and python_version < "4.0"
 pycparser==2.23 ; python_version >= "3.12" and python_version < "4.0" and implementation_name != "PyPy"
 pycryptodome==3.23.0 ; python_version >= "3.12" and python_version < "4.0"


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `pyasn1` `0.6.1` → `0.6.3`
**Manifest:** `requirements.txt`
**Severity:** high
**Advisory:** pyasn1 has a DoS vulnerability in decoder CVE-2026-23490, CVE-2026-30922

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `4591c7e39a857ae6` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"4591c7e39a857ae6","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->