### PR TITLE
Bump 2 dependencies in pyproject.toml (medium)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.12"
-mitmproxy = "^12.1.2"
+mitmproxy = "^12.2.2"
 flashtext = "2.7"
 presidio-analyzer = "2.2.352"
 presidio-anonymizer = "2.2.352"
@@ -21,7 +21,7 @@ hvac = "2.1.0"
 pybreaker = "^1.3.0"
 pydantic = "^2.5.0"
 pydantic-settings = "^2.2.1"
-requests = "^2.31.0"  # Needed for CLI stats fetching
+requests = "^2.33.0"  # Needed for CLI stats fetching
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
### FabGPT — OSV security bump

**Packages:**
- `mitmproxy` `12.1.2` → `12.2.2` (CVE-2026-40606)
- `requests` `2.31.0` → `2.33.0` (CVE-2024-35195, CVE-2024-47081, CVE-2026-25645)
**Manifest:** `pyproject.toml`
**Severity:** medium
**Advisories:** CVE-2024-35195, CVE-2024-47081, CVE-2026-25645, CVE-2026-40606

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `dbc096ae22de0641` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"dbc096ae22de0641","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->