### PR TITLE
privacy: link the shared privacy notice + meta-CSP

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,18 +6,25 @@ export default withMermaid(defineConfig({
     description: "Secure LLM Gateway with Data Loss Prevention",
     base: '/aidlp/',
     head: [
-    // Tutto first-party. 'unsafe-inline' serve perche' VitePress emette
-    // uno script inline per il tema e stili inline.
-    [
-      'meta',
-      {
-        'http-equiv': 'Content-Security-Policy',
-        content:
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
-          "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
-          "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
-      },
-    ],
+    // Everything this site loads is first-party. 'unsafe-inline' is required
+    // because VitePress emits an inline appearance script and inline styles.
+    // Applied to the built site only: `vitepress dev` serves HMR over a
+    // websocket, which a strict connect-src would block as soon as the dev
+    // server is not same-origin (--host, or a custom server.hmr.port).
+    ...(process.env.NODE_ENV === 'production'
+      ? [
+          [
+            'meta',
+            {
+              'http-equiv': 'Content-Security-Policy',
+              content:
+                "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
+                "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+                "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
+            },
+          ] as [string, Record<string, string>],
+        ]
+      : []),
         ['meta', { property: 'og:image', content: '/aidlp/banner.png' }],
         ['meta', { property: 'og:title', content: 'AI DLP Proxy' }],
         ['meta', { property: 'og:description', content: 'Secure Gateway for LLMs with Real-time PII Redaction' }],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,12 +6,28 @@ export default withMermaid(defineConfig({
     description: "Secure LLM Gateway with Data Loss Prevention",
     base: '/aidlp/',
     head: [
+    // Tutto first-party. 'unsafe-inline' serve perche' VitePress emette
+    // uno script inline per il tema e stili inline.
+    [
+      'meta',
+      {
+        'http-equiv': 'Content-Security-Policy',
+        content:
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; " +
+          "style-src 'self' 'unsafe-inline'; img-src 'self' data:; " +
+          "font-src 'self'; connect-src 'self'; base-uri 'self'; form-action 'self'",
+      },
+    ],
         ['meta', { property: 'og:image', content: '/aidlp/banner.png' }],
         ['meta', { property: 'og:title', content: 'AI DLP Proxy' }],
         ['meta', { property: 'og:description', content: 'Secure Gateway for LLMs with Real-time PII Redaction' }],
         ['link', { rel: 'icon', href: '/aidlp/favicon.ico' }]
     ],
     themeConfig: {
+    footer: {
+      message:
+        '<a href="https://fabriziosalmi.github.io/privacy">Privacy &amp; legal</a>',
+    },
         search: {
             provider: 'local'
         },


### PR DESCRIPTION
This project site had **no privacy notice**. Rather than adding another copy, it now links the canonical notice published once for every project site on this host:

### 🔗 https://fabriziosalmi.github.io/privacy

That notice is accurate for this site as-is — same publisher, same host (GitHub Pages), no cookies, no analytics, and the only device storage is the VitePress light/dark preference, which the notice describes. One document to maintain instead of ~25 copies drifting apart.

## Changes (one file, two additions)
- **`themeConfig.footer`** — a `Privacy & legal` link. VitePress renders the footer on the hero home page too, so it is reachable from **every** page without touching the nav.
- **`head`** — meta-CSP, `default-src 'self'`. `'unsafe-inline'` is required because VitePress emits an inline appearance script and inline styles.

## Verified
The same transform was applied across all the VitePress sites and validated by building **one representative of each config shape** (footer/head already present, created, or both) — all built clean, and the output HTML carries the link on both the home and inner pages, plus the CSP. Bracket balance checked on every config.

Pattern approved in fabriziosalmi/gitoma#48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)