### PR TITLE
Guard against empty term in add_term()

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -79,6 +79,10 @@ def add_term(term: str):
     """
     Add a static term to the blacklist.
     """
+    if not term or term.strip() == "":
+        typer.echo("Error: Term cannot be empty or whitespace-only.")
+        raise typer.Exit(1)
+
     provider_type = config.dlp.secrets_provider.type
     if provider_type == "vault":
         typer.echo(


### PR DESCRIPTION
### FabGPT — code quality

**File:** `src/cli.py`

**Rationale:** The `add_term()` function writes the term to the file with `f.write(f"\n{term}")` without checking if `term` is empty or whitespace-only. If a user passes an empty string or whitespace, this will add an empty line (or multiple if called repeatedly), corrupting the terms file. This is a real defect because `typer` allows empty string inputs by default unless explicitly constrained, and the code does not validate the input.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `2c708db30d16f659` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"2c708db30d16f659","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":2,"inference_s":15.8,"prompt_sha":"8f61bf83f8ef52a0","triage":"INFO"} -->