### PR TITLE
feat!: verify upstream TLS certificates by default (BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] - 2026-08-13
+
+### ⚠️ BREAKING: upstream TLS certificates are now verified
+
+Through 1.x, `proxy.ssl_bump` defaulted to `true`, and its only effect was to
+pass `--ssl-insecure` to mitmproxy — **disabling verification of the upstream
+server's certificate**. The name promised TLS interception and the documentation
+described it as "Enables HTTPS interception", but neither was true. The practical
+result: every stock deployment accepted any certificate the upstream presented,
+so the prompts this proxy exists to protect could be intercepted and altered in
+transit by anything that could answer for the endpoint.
+
+**Verification is now on by default.**
+
+- Added `proxy.upstream_insecure` (default `false`), and the matching
+  `--upstream-insecure` flag, as the explicit and only way to skip verification.
+- Enabling it logs a warning on every startup, from both the CLI and the
+  mitmproxy addon, so the state is visible even when `mitmdump` is driven
+  directly.
+- `proxy.ssl_bump` and `--ssl-bump` are **deprecated and inert**. Setting either
+  prints a deprecation notice and changes nothing.
+
+**Migration.** If you talk to an upstream with a private CA or a self-signed
+certificate and change nothing, connections will now fail with a certificate
+error. That is intended. Either trust the CA on the host, or opt back in with:
+
+```yaml
+proxy:
+  upstream_insecure: true   # accepts ANY upstream certificate
+```
+
+HTTPS interception towards *clients* is unaffected — that was always mitmproxy's
+own behaviour and never depended on this setting.
+
+### Fixed
+- `aidlp start` could not start at all: it passed `--ssl-version-client` and
+  `--ssl-version-server`, removed from mitmproxy years ago, and mitmdump exited
+  with "unrecognized arguments".
+- DLP was fail-open in three ways despite the fail-closed claim: a Vault outage
+  silently emptied the static term list; `Content-Type: application/octet-stream`
+  (or no header) bypassed body inspection entirely; query strings were never
+  inspected.
+- A disconnecting client could kill the ML workers permanently, after which every
+  request hung forever rather than failing closed.
+- The Docker image could not build (it copied a `poetry.lock` that was never
+  committed) and CI resolved dependencies that contradicted `pyproject.toml`.
+
+### Changed
+- Removed `upstream.default_scheme`, which no code ever read.
+- `proxy.port` and `proxy.host` are now actually honoured by `start`.
+- The image is built on every pull request, not only on tags.
+
 ## [1.9.7] - 2025-12-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ A high-performance, enterprise-grade HTTP/HTTPS Data Loss Prevention (DLP) proxy
 >
 > Full documentation is available at [https://fabriziosalmi.github.io/aidlp/](https://fabriziosalmi.github.io/aidlp/) (or locally via `npm run docs:dev`).
 
+> ⚠️ **Breaking change in 2.0.0 — upstream TLS certificates are now verified**
+>
+> Up to and including 1.x, `proxy.ssl_bump` defaulted to `true` and its only
+> effect was passing `--ssl-insecure` to mitmproxy, which **disabled
+> verification of the upstream server's certificate**. The name promised TLS
+> interception; it delivered the opposite of what it sounded like. Every stock
+> deployment accepted any certificate the upstream presented, so the prompts
+> this proxy exists to protect could be intercepted in transit.
+>
+> **From 2.0.0 verification is on by default.** `ssl_bump` is deprecated and
+> inert; setting it only prints a warning. If you deliberately need to reach an
+> upstream with an untrusted certificate — a private CA, a test endpoint — opt
+> in explicitly with `proxy.upstream_insecure: true` or `--upstream-insecure`,
+> and the proxy will warn on every startup while it is on.
+>
+> **If you use a private CA upstream and do nothing, connections will now fail**
+> with a certificate error. That is the intended behaviour. See
+> [#47](https://github.com/fabriziosalmi/aidlp/issues/47) for the migration
+> notes. HTTPS interception towards *clients* is unaffected.
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -73,7 +93,8 @@ The proxy uses `pydantic-settings` and can be configured via `config.yaml` or En
 proxy:
   port: 8080
   metrics_port: 9090
-  ssl_bump: true
+  # Skip upstream certificate verification. Leave false; see the note below.
+  upstream_insecure: false
 
 dlp:
   static_terms_file: "terms.txt"

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,13 @@
 proxy:
   port: 8080
   host: 0.0.0.0
-  ssl_bump: true
   metrics_port: 9090
+  # Skip verification of the upstream server's certificate. Leave this false.
+  # Turning it on accepts ANY certificate, so the prompts the proxy forwards
+  # can be intercepted and altered in transit -- redaction does not protect
+  # against that. Replaces the old `ssl_bump`, which did the same thing under
+  # a misleading name and defaulted to on.
+  upstream_insecure: false
 
 dlp:
   static_terms_file: "terms.txt"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-13
+
+### Removed (BREAKING)
+- `proxy.ssl_bump` and `--ssl-bump` are deprecated and inert. Through 1.x this
+  setting defaulted to `true` and its only effect was disabling verification of
+  the **upstream** server's TLS certificate — despite the name, and despite the
+  documentation describing it as "Enables HTTPS interception". Every stock
+  deployment therefore accepted any certificate the upstream presented, so
+  forwarded prompts could be intercepted and altered in transit.
+- `upstream.default_scheme`, which no code ever read.
+
+### Added
+- `proxy.upstream_insecure` (default `false`) and `--upstream-insecure`: the
+  explicit, and now only, way to skip upstream certificate verification. While
+  enabled, both the CLI and the mitmproxy addon warn on every startup.
+- Query-string values are redacted, on every HTTP method.
+- The Docker image is built on every pull request, not only on release tags.
+
+### Fixed
+- `aidlp start` could not start: it passed `--ssl-version-client` and
+  `--ssl-version-server`, removed from mitmproxy years ago.
+- A Vault outage silently emptied the static term list, forwarding secrets in
+  the clear; the term provider now keeps the last known good list.
+- `Content-Type: application/octet-stream`, or no header at all, bypassed body
+  inspection entirely.
+- A disconnecting client could permanently kill the ML workers, after which
+  every request hung instead of failing closed.
+- The Docker image could not build, and CI installed a dependency set that
+  contradicted `pyproject.toml`.
+
+### Migration
+If you reach an upstream through a private CA or a self-signed certificate and
+change nothing, connections will now fail with a certificate error. Either trust
+the CA on the host, or opt back in explicitly:
+
+```yaml
+proxy:
+  upstream_insecure: true   # accepts ANY upstream certificate
+```
+
+HTTPS interception towards *clients* is unaffected.
+
 ## [1.0.0] - 2026-04-28
 ### Added
 - Enterprise-grade AI DLP proxy architecture.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -19,8 +19,30 @@ upstream:
 | :--- | :--- | :--- | :--- |
 | `port` | `int` | `8080` | The TCP port where the proxy listens for incoming connections. |
 | `host` | `string` | `0.0.0.0` | The interface to bind to. `0.0.0.0` listens on all interfaces. |
-| `ssl_bump` | `bool` | `true` | Enables HTTPS interception. Requires CA cert installation on clients. |
 | `metrics_port` | `int` | `9090` | Port for the Prometheus metrics server. |
+| `upstream_insecure` | `bool` | `false` | Skip verification of the upstream server's TLS certificate. **Leave this off.** See the warning below. |
+| `ssl_bump` | `bool` | — | **Deprecated in 2.0.0 and inert.** Setting it only prints a warning. |
+
+::: danger upstream_insecure disables a security control
+Turning `upstream_insecure` on makes the proxy accept **any** certificate the
+upstream presents, so the prompts it forwards can be intercepted and altered in
+transit. Redaction does not protect against that.
+
+Only use it against a known upstream with a private CA, never on the open
+internet. The proxy logs a warning on every startup while it is on.
+:::
+
+::: warning Renamed from `ssl_bump` in 2.0.0
+`ssl_bump` never enabled TLS interception, despite the name and despite what
+this page previously claimed. Its one real effect was disabling upstream
+certificate verification — and it defaulted to `true`, so every stock
+deployment accepted any upstream certificate.
+
+Verification is now on by default. If you relied on the old behaviour, set
+`upstream_insecure: true` explicitly. HTTPS interception itself is unaffected
+and still requires the CA certificate on clients; that was always handled by
+mitmproxy, not by this setting.
+:::
 
 ## DLP Settings
 
@@ -37,12 +59,6 @@ upstream:
 | `secrets_provider.vault.path` | `string` | - | Path to the KV secret (e.g., `aidlp/terms`). |
 | `secrets_provider.vault.token` | `string` | - | Vault token. **Recommended:** Use `VAULT_TOKEN` env var instead. |
 
-## Upstream Settings
-
-| Key | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `default_scheme` | `string` | `https` | Default protocol for upstream requests if not specified. |
-
 ## Environment Variables
 
 Sensitive configuration can be overridden via environment variables:
@@ -58,8 +74,8 @@ proxy:
   port: 8080
   # The port for Prometheus metrics
   metrics_port: 9090
-  # Enable SSL interception (required for DLP)
-  ssl_bump: true
+  # Skip verification of the upstream certificate. Leave this false.
+  upstream_insecure: false
 
 dlp:
   # Path to file containing static sensitive terms (one per line)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aidlp"
-version = "1.0.0"
+version = "2.0.0"
 description = "AI Data Loss Prevention Proxy"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 readme = "README.md"

--- a/src/cli.py
+++ b/src/cli.py
@@ -9,11 +9,31 @@ from src.config import config
 app = typer.Typer()
 
 
+SSL_BUMP_DEPRECATED = (
+    "WARNING: ssl_bump is deprecated and no longer has any effect.\n"
+    "  It never enabled TLS interception, whatever the name suggested: its\n"
+    "  only effect was to disable verification of the upstream server's\n"
+    "  certificate, and it was on by default.\n"
+    "  Verification is now ON. If you genuinely need to talk to an upstream\n"
+    "  with an untrusted certificate, ask for it explicitly with\n"
+    "  --upstream-insecure (or proxy.upstream_insecure in config.yaml)."
+)
+
+UPSTREAM_INSECURE_WARNING = (
+    "WARNING: upstream TLS certificate verification is DISABLED.\n"
+    "  The proxy will accept any certificate the upstream presents, so the\n"
+    "  prompts it forwards can be intercepted and altered in transit.\n"
+    "  Redaction does not protect you from that. Use this only against a\n"
+    "  known upstream with a private CA, never on the open internet."
+)
+
+
 @app.command()
 def start(
     port: Optional[int] = None,
     host: Optional[str] = None,
-    ssl_bump: bool = True,
+    upstream_insecure: Optional[bool] = None,
+    ssl_bump: Optional[bool] = None,
 ):
     """
     Start the DLP Proxy.
@@ -21,6 +41,12 @@ def start(
     # Fall back to config.yaml / AIDLP_* env vars when not given on the CLI.
     port = port if port is not None else config.proxy.port
     host = host if host is not None else config.proxy.host
+
+    if ssl_bump is not None or config.proxy.ssl_bump is not None:
+        typer.secho(SSL_BUMP_DEPRECATED, fg=typer.colors.YELLOW, err=True)
+
+    if upstream_insecure is None:
+        upstream_insecure = config.proxy.upstream_insecure
 
     typer.echo(f"Starting DLP Proxy on {host}:{port}...")
 
@@ -41,8 +67,9 @@ def start(
         "tls_version_server_min=TLS1_2",
     ]
 
-    if ssl_bump:
+    if upstream_insecure:
         cmd.extend(["--ssl-insecure"])
+        typer.secho(UPSTREAM_INSECURE_WARNING, fg=typer.colors.RED, err=True)
 
     # Set PYTHONPATH so mitmproxy can find src modules
     env = os.environ.copy()

--- a/src/config.py
+++ b/src/config.py
@@ -37,8 +37,18 @@ class DLPConfig(BaseModel):
 class ProxyConfig(BaseModel):
     port: int = 8080
     host: str = "0.0.0.0"
-    ssl_bump: bool = True
     metrics_port: int = 9090
+
+    # Skip verification of the certificate presented by the upstream server.
+    # Turning this on means the proxy accepts ANY certificate, so the prompts
+    # it forwards can be read and altered in transit by whoever answers.
+    # Defaults to off since 2.0.0; before that it was effectively on.
+    upstream_insecure: bool = False
+
+    # Deprecated in 2.0.0, kept only so an existing config.yaml is reported
+    # rather than silently ignored. The name always promised TLS interception;
+    # its one real effect was disabling upstream verification.
+    ssl_bump: Optional[bool] = None
 
 
 class AppConfig(BaseSettings):

--- a/src/proxy_core.py
+++ b/src/proxy_core.py
@@ -126,10 +126,12 @@ class DLPAddon:
             return False
 
         logger.warning(
-            "Upstream TLS certificate verification is DISABLED. The proxy "
-            "will accept any certificate the upstream presents, so redacted "
-            "prompts can still be intercepted and altered in transit. Unset "
-            "proxy.upstream_insecure to restore verification."
+            "Upstream TLS certificate verification is DISABLED "
+            "(mitmproxy option ssl_insecure). The proxy will accept any "
+            "certificate the upstream presents, so redacted prompts can still "
+            "be intercepted and altered in transit. To restore verification: "
+            "drop --ssl-insecure if you launch mitmdump directly, or unset "
+            "proxy.upstream_insecure if you start via the aidlp CLI."
         )
         return True
 

--- a/src/proxy_core.py
+++ b/src/proxy_core.py
@@ -2,7 +2,7 @@ import errno
 import json
 import logging
 import os
-from mitmproxy import http
+from mitmproxy import ctx, http
 from src.dlp_engine import DLPEngine
 from src.config import config
 from prometheus_client import start_http_server, Counter, Histogram, Gauge
@@ -114,7 +114,32 @@ class DLPAddon:
             logger.error(f"Failed to start Prometheus server: {e}")
         logger.info("DLP Engine initialized")
 
+    @staticmethod
+    def warn_if_upstream_unverified(options) -> bool:
+        """Log a warning when upstream certificate verification is off.
+
+        The CLI warns too, but mitmdump can be driven directly -- the
+        deployment guide does exactly that -- so check the option we are
+        actually running with rather than trusting the launcher.
+        """
+        if options is None or not getattr(options, "ssl_insecure", False):
+            return False
+
+        logger.warning(
+            "Upstream TLS certificate verification is DISABLED. The proxy "
+            "will accept any certificate the upstream presents, so redacted "
+            "prompts can still be intercepted and altered in transit. Unset "
+            "proxy.upstream_insecure to restore verification."
+        )
+        return True
+
     def running(self):
+        try:
+            options = ctx.options
+        except Exception:
+            # Not running under a mitmproxy master (unit tests, imports).
+            options = None
+        self.warn_if_upstream_unverified(options)
         self.dlp_engine.start_workers()
 
     async def request(self, flow: http.HTTPFlow):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 from typer.testing import CliRunner
 
 from src.cli import app
+from src.config import config
 
 runner = CliRunner()
 
@@ -18,7 +19,18 @@ def test_start_default(mock_run):
     assert "mitmdump" in cmd
     assert "-p" in cmd
     assert "8080" in cmd
-    assert "--ssl-insecure" in cmd
+
+
+@patch("src.cli.os.execvpe")
+def test_start_verifies_upstream_by_default(mock_run):
+    """The default must not disable upstream certificate verification.
+
+    Until 2.0.0 `ssl_bump` defaulted to true and mapped straight to
+    --ssl-insecure, so every stock deployment accepted any upstream
+    certificate.
+    """
+    runner.invoke(app, ["start"])
+    assert "--ssl-insecure" not in mock_run.call_args[0][1]
 
 
 @patch("src.cli.os.execvpe")
@@ -31,11 +43,38 @@ def test_start_custom_port(mock_run):
 
 
 @patch("src.cli.os.execvpe")
-def test_start_no_ssl_bump(mock_run):
-    result = runner.invoke(app, ["start", "--no-ssl-bump"])
+def test_start_upstream_insecure_is_opt_in(mock_run):
+    result = runner.invoke(app, ["start", "--upstream-insecure"])
     assert result.exit_code == 0
-    cmd = mock_run.call_args[0][1]
-    assert "--ssl-insecure" not in cmd
+    assert "--ssl-insecure" in mock_run.call_args[0][1]
+    # Turning verification off must never be quiet.
+    assert "verification is DISABLED" in result.output
+
+
+@patch("src.cli.os.execvpe")
+def test_start_upstream_insecure_from_config(mock_run):
+    with patch.object(config.proxy, "upstream_insecure", True):
+        result = runner.invoke(app, ["start"])
+    assert result.exit_code == 0
+    assert "--ssl-insecure" in mock_run.call_args[0][1]
+
+
+@patch("src.cli.os.execvpe")
+def test_deprecated_ssl_bump_warns_and_does_not_disable_verification(mock_run):
+    """`--ssl-bump` used to disable verification. It must now be inert."""
+    result = runner.invoke(app, ["start", "--ssl-bump"])
+    assert result.exit_code == 0
+    assert "ssl_bump is deprecated" in result.output
+    assert "--ssl-insecure" not in mock_run.call_args[0][1]
+
+
+@patch("src.cli.os.execvpe")
+def test_deprecated_ssl_bump_in_config_warns(mock_run):
+    with patch.object(config.proxy, "ssl_bump", True):
+        result = runner.invoke(app, ["start"])
+    assert result.exit_code == 0
+    assert "ssl_bump is deprecated" in result.output
+    assert "--ssl-insecure" not in mock_run.call_args[0][1]
 
 
 @patch("src.cli.os.execvpe")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,29 @@
+import logging
 import pytest
 from unittest.mock import AsyncMock
 from mitmproxy.test import tflow
 from src.proxy_core import DLPAddon
+
+
+class _Options:
+    def __init__(self, ssl_insecure):
+        self.ssl_insecure = ssl_insecure
+
+
+def test_warns_when_upstream_verification_is_disabled(caplog):
+    """Running without upstream verification must never be silent.
+
+    mitmdump can be driven directly, bypassing the CLI's own warning, so
+    the addon checks the option it actually runs with.
+    """
+    with caplog.at_level(logging.WARNING, logger="dlp_proxy"):
+        assert DLPAddon.warn_if_upstream_unverified(_Options(True)) is True
+    assert "verification is DISABLED" in caplog.text
+
+
+def test_no_warning_when_upstream_verification_is_enabled():
+    assert DLPAddon.warn_if_upstream_unverified(_Options(False)) is False
+    assert DLPAddon.warn_if_upstream_unverified(None) is False
 
 
 def _flow(content=b"test", content_type="text/plain", path=None):


### PR DESCRIPTION
Closes #47.

## What was wrong

Through 1.x, `proxy.ssl_bump` defaulted to `true`, and its only effect was passing `--ssl-insecure` to mitmproxy — which **disables verification of the upstream server's certificate**.

The name promised TLS interception. `docs/reference/config.md` went further and stated it outright:

> | `ssl_bump` | `bool` | `true` | Enables HTTPS interception. Requires CA cert installation on clients. |

Neither was true. Interception towards clients is mitmproxy's own behaviour and never depended on this setting. What the flag actually did was make the proxy accept **any** certificate the upstream presented — on by default, in a tool whose entire purpose is protecting data on its way to LLM endpoints. Redaction does not help here: a redacted prompt intercepted in transit is still an intercepted prompt, and the connection can be altered in both directions.

So the default was insecure, the name pointed the wrong way, and the documentation actively confirmed the wrong reading.

## What changes

Verification is **on by default**.

- New `proxy.upstream_insecure` (default `false`) and `--upstream-insecure` — the explicit, and now only, way to skip verification.
- While it is on, both the CLI and the mitmproxy addon warn at startup. The addon inspects the option it is *actually running with*, so driving `mitmdump` directly — which `docs/guide/deployment.md` does — is covered too, not just the CLI path.
- `ssl_bump` / `--ssl-bump` are accepted but **inert**, and print a deprecation notice. Silently ignoring them was rejected deliberately: an operator who has `ssl_bump: true` in their config today believes verification is off, and needs to be told it is now on.

What the user sees:

```
$ aidlp start --ssl-bump
WARNING: ssl_bump is deprecated and no longer has any effect.
  It never enabled TLS interception, whatever the name suggested: its
  only effect was to disable verification of the upstream server's
  certificate, and it was on by default.
  Verification is now ON. If you genuinely need to talk to an upstream
  with an untrusted certificate, ask for it explicitly with
  --upstream-insecure (or proxy.upstream_insecure in config.yaml).

$ aidlp start --upstream-insecure
WARNING: upstream TLS certificate verification is DISABLED.
  The proxy will accept any certificate the upstream presents, so the
  prompts it forwards can be intercepted and altered in transit.
  Redaction does not protect you from that. Use this only against a
  known upstream with a private CA, never on the open internet.
```

## Breaking change and migration

**If you reach an upstream through a private CA or a self-signed certificate and change nothing, connections will now fail with a certificate error.** That is the intended outcome — previously they "worked" because nothing was checked.

Either trust the CA on the host, or opt back in explicitly:

```yaml
proxy:
  upstream_insecure: true   # accepts ANY upstream certificate
```

Interception towards *clients* is unaffected.

## Disclosure

- `CHANGELOG.md` and the published `docs/CHANGELOG.md` carry a BREAKING entry with migration steps.
- `README.md` opens with the notice.
- `docs/reference/config.md`: the false description is corrected, with a danger callout on `upstream_insecure` and a warning explaining the rename.
- Version bumped to **2.0.0** — semver-correct for a change that breaks working deployments.
- A security advisory and a pinned migration issue follow this PR.

## Verification

36 tests pass (6 new), flake8 clean, `poetry check --lock` still green after the version bump. The new tests assert the default carries no `--ssl-insecure`, that the opt-in adds it *and* warns, that the deprecated flag warns without re-enabling insecurity, and that the addon warns on the option it actually runs with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)