### PR TITLE
fix: let environment variables actually override config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2026-08-13
+
+### Changed: environment variables now take precedence over `config.yaml`
+
+They always should have. Both the README and `docs/reference/config.md` stated
+it plainly. But `config.yaml` was loaded via `AppConfig(**raw_config)`, and in
+`pydantic-settings` constructor arguments outrank every other source — so the
+file quietly beat the environment.
+
+The consequences were exactly the kind that go unnoticed:
+
+- `AIDLP_PROXY__UPSTREAM_INSECURE=false`, set to harden a deployment, could be
+  undone by a stale `upstream_insecure: true` in a file — re-disabling the
+  upstream certificate verification that 2.0.0 had just made the default.
+- `AIDLP_DLP__ML_ENABLED=true` could be overridden into disabling ML redaction
+  entirely, leaving static term matching as the only protection, with nothing
+  announcing the downgrade.
+- `docker-compose.yml` ships `AIDLP_*` variables and assumes they win. They only
+  did because the image happens not to contain a `config.yaml`.
+
+Precedence is now, highest first: **environment → `config.yaml` → defaults**.
+Sources merge key by key, so setting one variable no longer discards the rest of
+a section.
+
+### Added
+- Startup logs a warning naming every `config.yaml` key an environment variable
+  overrides, so the conflict is stated rather than silent.
+
+### Migration
+If you run with both a `config.yaml` and `AIDLP_*` variables covering the same
+keys, your effective configuration changes with this release. The new startup
+warning names precisely which keys are affected; confirm the resulting values
+are the ones you want, especially `proxy.upstream_insecure` and `dlp.ml_enabled`.
+
 ## [2.0.0] - 2026-08-13
 
 ### ⚠️ BREAKING: upstream TLS certificates are now verified

--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ curl -x http://localhost:8080 http://httpbin.org/ip
 
 ## Configuration
 
-The proxy uses `pydantic-settings` and can be configured via `config.yaml` or Environment Variables (prefix: `AIDLP_`). Environment variables take precedence.
+The proxy uses `pydantic-settings` and can be configured via `config.yaml` or Environment Variables (prefix: `AIDLP_`).
+
+**Precedence, highest first:** environment variables → `config.yaml` → built-in defaults.
+
+> ⚠️ Before **2.1.0** this was the other way round: `config.yaml` silently beat the environment, despite this page having always claimed otherwise. If you have both, check which values actually apply after upgrading — the proxy now logs a warning naming every `config.yaml` key an environment variable overrides.
 
 ### `config.yaml`
 ```yaml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-08-13
+
+### Changed (behavioural)
+- **Environment variables now take precedence over `config.yaml`.** They always
+  should have — the README and this reference both said so — but the file was
+  loaded as constructor arguments, and those outrank every other source in
+  `pydantic-settings`. The file silently won.
+
+  This was quiet and it mattered. An `AIDLP_PROXY__UPSTREAM_INSECURE=false` set
+  to harden a deployment could be undone by a leftover `upstream_insecure: true`
+  in a file, re-disabling the certificate verification that 2.0.0 had just made
+  the default. An `AIDLP_DLP__ML_ENABLED=true` could likewise be overridden into
+  turning ML redaction off entirely, leaving static term matching as the only
+  protection with nothing reporting the downgrade.
+
+  Precedence is now, highest first: environment → `config.yaml` → defaults.
+  Sources merge key by key, so one variable no longer discards the rest of a
+  section.
+
+### Added
+- Startup logs a warning naming every `config.yaml` key that an environment
+  variable overrides, so the conflict is visible instead of silent.
+
+### Migration
+If you run with both a `config.yaml` and `AIDLP_*` variables setting the same
+keys, the effective configuration changes with this release. Check the startup
+warning to see exactly which keys are affected, and confirm the values are the
+ones you intend — particularly `proxy.upstream_insecure` and `dlp.ml_enabled`.
+
 ## [2.0.0] - 2026-08-13
 
 ### Removed (BREAKING)

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -61,7 +61,38 @@ mitmproxy, not by this setting.
 
 ## Environment Variables
 
-Sensitive configuration can be overridden via environment variables:
+Any setting can be supplied through an `AIDLP_`-prefixed variable, using `__`
+to descend into nested keys — `AIDLP_DLP__SECRETS_PROVIDER__TYPE` maps to
+`dlp.secrets_provider.type`.
+
+### Precedence
+
+Highest first:
+
+1. Environment variables (`AIDLP_*`)
+2. `config.yaml`
+3. Built-in defaults
+
+Sources are merged key by key, so setting one variable does not discard the rest
+of a `config.yaml` section.
+
+::: warning Reversed in 2.1.0
+Before 2.1.0 `config.yaml` was loaded as constructor arguments, which outrank
+every other source in `pydantic-settings`. The file therefore **beat** the
+environment — the opposite of what this page and the README described, and the
+opposite of what `docker-compose.yml` assumed.
+
+The practical consequences were quiet and unpleasant: an
+`AIDLP_PROXY__UPSTREAM_INSECURE=false` meant to harden a deployment could be
+undone by a stale `upstream_insecure: true` in a file, and an
+`AIDLP_DLP__ML_ENABLED=true` could be silenced into disabling ML redaction
+altogether.
+
+Since 2.1.0 the order above holds, and startup logs a warning naming every
+`config.yaml` key that an environment variable overrides.
+:::
+
+Other variables:
 
 - `VAULT_TOKEN`: Authentication token for HashiCorp Vault.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aidlp"
-version = "2.0.0"
+version = "2.1.0"
 description = "AI Data Loss Prevention Proxy"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 readme = "README.md"

--- a/src/config.py
+++ b/src/config.py
@@ -92,10 +92,25 @@ def _read_yaml(config_path: str) -> dict:
 
     try:
         with open(config_path, "r") as f:
-            return yaml.safe_load(f) or {}
+            data = yaml.safe_load(f)
     except Exception as e:
         logger.critical(f"Failed to load yaml config: {e}")
         raise
+
+    if data is None:  # empty file
+        return {}
+
+    if not isinstance(data, dict):
+        # A top-level list or scalar would otherwise reach the settings
+        # source and fail somewhere far less informative.
+        message = (
+            f"Config file {config_path} must contain a mapping at the top "
+            f"level, got {type(data).__name__}."
+        )
+        logger.critical(message)
+        raise TypeError(message)
+
+    return data
 
 
 def find_env_shadowed_keys(raw_config: dict, environ=None) -> list[str]:
@@ -146,8 +161,12 @@ def load_config(config_path: str = "config.yaml") -> AppConfig:
             # First source wins. Environment beats the YAML file, which
             # beats the field defaults -- the order the README always
             # documented and docker-compose.yml always assumed.
+            #
+            # init_settings is deliberately absent: load_config passes no
+            # keyword arguments, and leaving it in would keep a silent tier
+            # above the environment. That extra tier is exactly what caused
+            # this bug in the first place.
             return (
-                init_settings,
                 env_settings,
                 dotenv_settings,
                 _MappingSource(settings_cls, raw_config),

--- a/src/config.py
+++ b/src/config.py
@@ -3,7 +3,11 @@ import logging
 import yaml
 from typing import Optional, List
 from pydantic import BaseModel, Field, ValidationError
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 
 logger = logging.getLogger("dlp_proxy")
 
@@ -60,20 +64,98 @@ class AppConfig(BaseSettings):
     )
 
 
-def load_config(config_path: str = "config.yaml") -> AppConfig:
-    raw_config = {}
-    if os.path.exists(config_path):
-        try:
-            with open(config_path, "r") as f:
-                raw_config = yaml.safe_load(f) or {}
-        except Exception as e:
-            logger.critical(f"Failed to load yaml config: {e}")
-            raise
-    else:
+class _MappingSource(PydanticBaseSettingsSource):
+    """Feed an already-parsed mapping in as an ordinary settings source.
+
+    The YAML file used to be passed as init keyword arguments, and in
+    pydantic-settings those outrank every other source. So config.yaml
+    silently beat the AIDLP_* environment variables that the README
+    promised would win -- quietly undoing, among other things, an
+    AIDLP_PROXY__UPSTREAM_INSECURE=false meant to harden a deployment.
+    """
+
+    def __init__(self, settings_cls, data: dict):
+        super().__init__(settings_cls)
+        self._data = data
+
+    def get_field_value(self, field, field_name):
+        return self._data.get(field_name), field_name, False
+
+    def __call__(self) -> dict:
+        return self._data
+
+
+def _read_yaml(config_path: str) -> dict:
+    if not os.path.exists(config_path):
         logger.warning(f"Config file {config_path} not found. Using defaults/env vars.")
+        return {}
 
     try:
-        return AppConfig(**raw_config)
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.critical(f"Failed to load yaml config: {e}")
+        raise
+
+
+def find_env_shadowed_keys(raw_config: dict, environ=None) -> list[str]:
+    """List config.yaml keys that an AIDLP_* variable takes precedence over.
+
+    Silently winning is how this went unnoticed for so long, in both
+    directions. Name the conflicts instead.
+    """
+    environ = os.environ if environ is None else environ
+    shadowed: list[str] = []
+
+    def walk(node, path):
+        if not isinstance(node, dict):
+            return
+        for key, value in node.items():
+            here = path + [str(key)]
+            if isinstance(value, dict):
+                walk(value, here)
+                continue
+            var = "AIDLP_" + "__".join(p.upper() for p in here)
+            if var in environ:
+                shadowed.append(f"{'.'.join(here)} (overridden by {var})")
+
+    walk(raw_config, [])
+    return sorted(shadowed)
+
+
+def load_config(config_path: str = "config.yaml") -> AppConfig:
+    raw_config = _read_yaml(config_path)
+
+    shadowed = find_env_shadowed_keys(raw_config)
+    if shadowed:
+        logger.warning(
+            "Environment variables override these config.yaml keys: "
+            + "; ".join(shadowed)
+        )
+
+    class _AppConfig(AppConfig):
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls,
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+        ):
+            # First source wins. Environment beats the YAML file, which
+            # beats the field defaults -- the order the README always
+            # documented and docker-compose.yml always assumed.
+            return (
+                init_settings,
+                env_settings,
+                dotenv_settings,
+                _MappingSource(settings_cls, raw_config),
+                file_secret_settings,
+            )
+
+    try:
+        return _AppConfig()
     except ValidationError as e:
         logger.critical(f"Configuration validation failed: {e}")
         raise

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from src.config import find_env_shadowed_keys, load_config
 
 def _write(tmp_path, data):
     path = tmp_path / "config.yaml"
-    path.write_text(yaml.dump(data))
+    path.write_text(yaml.safe_dump(data))
     return str(path)
 
 
@@ -72,8 +72,24 @@ def test_malformed_yaml_raises(tmp_path):
     path = tmp_path / "config.yaml"
     path.write_text("proxy: [unclosed\n")
 
-    with pytest.raises(Exception):
+    with pytest.raises(yaml.YAMLError):
         load_config(str(path))
+
+
+def test_non_mapping_yaml_raises_a_clear_error(tmp_path):
+    """A top-level list would otherwise fail deep inside the settings source."""
+    path = tmp_path / "config.yaml"
+    path.write_text("- proxy\n- dlp\n")
+
+    with pytest.raises(TypeError, match="must contain a mapping"):
+        load_config(str(path))
+
+
+def test_empty_yaml_falls_back_to_defaults(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("")
+
+    assert load_config(str(path)).proxy.port == 8080
 
 
 def test_find_env_shadowed_keys_reports_nested_conflicts():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,99 @@
+import pytest
+import yaml
+
+from src.config import find_env_shadowed_keys, load_config
+
+
+def _write(tmp_path, data):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.dump(data))
+    return str(path)
+
+
+def test_environment_beats_yaml(tmp_path, monkeypatch):
+    """The precedence the README always documented, and never had.
+
+    Until 2.1.0 the YAML was passed as init kwargs, which outrank every
+    other source in pydantic-settings, so config.yaml silently won.
+    """
+    path = _write(tmp_path, {"dlp": {"replacement_token": "[YAML]"}})
+    monkeypatch.setenv("AIDLP_DLP__REPLACEMENT_TOKEN", "[ENV]")
+
+    assert load_config(path).dlp.replacement_token == "[ENV]"
+
+
+def test_environment_cannot_be_overridden_into_insecure_tls(tmp_path, monkeypatch):
+    """A stale config.yaml must not undo a hardened environment.
+
+    An operator setting AIDLP_PROXY__UPSTREAM_INSECURE=false is asking for
+    upstream certificate verification. A leftover `upstream_insecure: true`
+    used to win that argument silently.
+    """
+    path = _write(tmp_path, {"proxy": {"upstream_insecure": True}})
+    monkeypatch.setenv("AIDLP_PROXY__UPSTREAM_INSECURE", "false")
+
+    assert load_config(path).proxy.upstream_insecure is False
+
+
+def test_environment_cannot_be_overridden_into_disabled_ml(tmp_path, monkeypatch):
+    path = _write(tmp_path, {"dlp": {"ml_enabled": False}})
+    monkeypatch.setenv("AIDLP_DLP__ML_ENABLED", "true")
+
+    assert load_config(path).dlp.ml_enabled is True
+
+
+def test_yaml_beats_defaults(tmp_path, monkeypatch):
+    monkeypatch.delenv("AIDLP_PROXY__METRICS_PORT", raising=False)
+    path = _write(tmp_path, {"proxy": {"metrics_port": 7777}})
+
+    assert load_config(path).proxy.metrics_port == 7777
+
+
+def test_sources_merge_per_key(tmp_path, monkeypatch):
+    """Env overriding one key must not discard the rest of the YAML section."""
+    path = _write(
+        tmp_path,
+        {"dlp": {"replacement_token": "[YAML]", "ml_threshold": 0.9}},
+    )
+    monkeypatch.setenv("AIDLP_DLP__REPLACEMENT_TOKEN", "[ENV]")
+
+    config = load_config(path)
+    assert config.dlp.replacement_token == "[ENV]"
+    assert config.dlp.ml_threshold == 0.9  # untouched by the environment
+    assert config.dlp.static_terms_file == "terms.txt"  # still the default
+
+
+def test_missing_file_falls_back_to_defaults(tmp_path):
+    config = load_config(str(tmp_path / "nope.yaml"))
+    assert config.proxy.port == 8080
+
+
+def test_malformed_yaml_raises(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("proxy: [unclosed\n")
+
+    with pytest.raises(Exception):
+        load_config(str(path))
+
+
+def test_find_env_shadowed_keys_reports_nested_conflicts():
+    raw = {
+        "proxy": {"port": 8080, "upstream_insecure": True},
+        "dlp": {"secrets_provider": {"type": "file"}},
+    }
+    environ = {
+        "AIDLP_PROXY__UPSTREAM_INSECURE": "false",
+        "AIDLP_DLP__SECRETS_PROVIDER__TYPE": "vault",
+    }
+
+    shadowed = find_env_shadowed_keys(raw, environ)
+
+    assert shadowed == [
+        "dlp.secrets_provider.type (overridden by AIDLP_DLP__SECRETS_PROVIDER__TYPE)",
+        "proxy.upstream_insecure (overridden by AIDLP_PROXY__UPSTREAM_INSECURE)",
+    ]
+
+
+def test_find_env_shadowed_keys_silent_without_conflicts():
+    raw = {"proxy": {"port": 8080}}
+    assert find_env_shadowed_keys(raw, {"AIDLP_DLP__ML_ENABLED": "true"}) == []


### PR DESCRIPTION
Closes #48.

## What was wrong

`README.md` and `docs/reference/config.md` both stated that `AIDLP_*` environment variables take precedence over `config.yaml`. They did not.

`config.yaml` was loaded with `AppConfig(**raw_config)`, and in `pydantic-settings` constructor arguments are the **highest** priority source — above environment variables. So the file silently won every conflict.

Reproduced on `main` before the fix:

```
env AIDLP_PROXY__UPSTREAM_INSECURE=false, yaml true   -> True
env AIDLP_DLP__ML_ENABLED=true,           yaml false  -> False
env AIDLP_DLP__REPLACEMENT_TOKEN=[ENV],   yaml [YAML] -> [YAML]
```

Same shape as #47: the documentation described the opposite of the behaviour, so nobody reading the configuration had a way to notice.

## Why it matters more than a config nit

- **The first line undoes #47.** An operator setting `AIDLP_PROXY__UPSTREAM_INSECURE=false` is explicitly asking for upstream certificate verification. A stale `upstream_insecure: true` in a file beat it — silently re-disabling the protection 2.0.0 had just made the default.
- **The second silently downgrades DLP.** `AIDLP_DLP__ML_ENABLED=true` losing to `ml_enabled: false` leaves static term matching as the only protection, with nothing reporting the downgrade.
- **`docker-compose.yml` assumes environment wins.** It ships `AIDLP_PROXY__*` and `AIDLP_DLP__*` variables. Those work today only because the image happens not to contain a `config.yaml`. Mount one, or `COPY` it in, and they quietly stop applying.

Environment variables are the standard way to harden a deployment in Kubernetes, systemd and compose. Having them silently ignored is the wrong failure direction.

## The fix

The YAML now arrives through an ordinary settings source ranked *below* the environment:

**environment → `config.yaml` → defaults**

Sources merge key by key, so setting one variable no longer discards the rest of a section. Verified:

```
port           env=1234, yaml=9999 ->  1234      (env wins)
metrics_port   yaml=7777 only      ->  7777      (yaml beats the default)
ml_threshold   yaml=0.9 only       ->  0.9       (default was 0.5)
host           no source           ->  0.0.0.0   (default)
```

Startup also warns, naming each conflict:

```
WARNING Environment variables override these config.yaml keys:
  dlp.ml_enabled (overridden by AIDLP_DLP__ML_ENABLED);
  proxy.upstream_insecure (overridden by AIDLP_PROXY__UPSTREAM_INSECURE)
```

Silently winning is how this survived unnoticed in both directions, so the conflict is now stated out loud rather than resolved in private.

## Breaking-ish

If you run with both a `config.yaml` and `AIDLP_*` variables covering the same keys, your effective configuration changes. That is the point — it now matches what was always documented — but it is a real behavioural change, so this is **2.1.0** with a migration note in both changelogs and a warning banner in the README.

## Verification

45 tests pass (9 new, in a new `tests/test_config.py`), flake8 clean, `poetry check --lock` green after the version bump.

Mutation-checked: restoring the old source ordering fails exactly the four precedence tests and leaves the other five green.

One note on that check — the first attempt was misleading. The mutation was a pure reordering of lines, so the file kept the same size and landed in the same mtime second, and Python happily reused the stale `.pyc`. The restored run reported failures that were not real. Clearing `__pycache__` gave the honest result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)