### PR TITLE
Fix missing assertion in test_binary_content_type_is_skipped

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -103,7 +103,7 @@ async def test_binary_content_type_is_skipped():
     f = _flow(content=b"\x89PNG\r\n\x1a\n", content_type="image/png")
     await addon.request(f)
 
-    addon.dlp_engine.redact.assert_not_awaited()
+    addon.dlp_engine.redact.assert_not_called()
     addon.dlp_engine.shutdown()
 
 


### PR DESCRIPTION
### FabGPT — code quality

**File:** `tests/test_integration.py`

**Rationale:** In test_binary_content_type_is_skipped, the test asserts that `addon.dlp_engine.redact.assert_not_awaited()` is called, but this assertion is invalid because `assert_not_awaited()` is not a valid method on AsyncMock — the correct method is `assert_not_called()`. This is a real defect because the test will raise an AttributeError at runtime when executed, causing the test to fail unexpectedly rather than correctly validate that redact was not called.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `343ff2400dd6de54` · HITL-approved before opening.

<details>
<summary><b>How this change was checked</b> — 4 gates before a human saw it</summary>

| gate | result |
|---|---|
| deterministic slop gates | passed — no known no-op / false-guard pattern |
| LLM reviewer | `ship` · 90/100 |
| adversarial panel | survived — 2/3 could not refute (correctness, necessity, reproducibility) · dissent: **correctness** `assert_not_awaited()` is a valid AsyncMock method, so the change is unnecessary. |
| human review | read and approved before this PR was opened |

The adversarial panel is three independent skeptics — correctness, necessity, reproducibility — each defaulting to *refuted*, voting “cannot refute” only after failing to find a reason to reject. A gate that did not run is not listed.
</details>
<!-- fabgpt:{"task_id":"343ff2400dd6de54","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":7.71,"prompt_sha":"9e70bae575a22f07","triage":"INFO","review":{"verdict":"ship","score":90},"escalation":{"verdict":"OK","refuted":1,"model":"gpt-oss-120b"}} -->