### PR TITLE
feat!: authenticate proxy callers and stop binding the world by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy to `.env` (git-ignored) before running `docker compose up`.
+# Both variables are mandatory: docker-compose.yml declares them with `:?`
+# and refuses to start rather than fall back to a value shipped in the repo.
+
+# Shared secret callers present to the proxy, as
+#   Proxy-Authorization: Bearer <token>
+# or  Proxy-Authorization: Basic base64(anyuser:<token>)
+# Generate one with:  openssl rand -hex 32
+AIDLP_PROXY_AUTH_TOKEN=
+
+# Grafana admin password. Replaces the hardcoded `admin` default.
+GF_SECURITY_ADMIN_PASSWORD=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2026-09-07
+
+### ⚠️ BREAKING: the proxy no longer relays for anonymous callers
+
+`DLPAddon.request` forwarded every request once DLP redaction had run, with
+nothing establishing who the caller was. Combined with a default bind of
+`0.0.0.0`, any host that could reach the port could use the proxy to fetch
+whatever upstream a request named, and could read the unauthenticated
+Prometheus endpoint. An open relay is a poor thing for a data-loss-prevention
+appliance to be.
+
+- Added `proxy.auth_token`. When set, callers must present
+  `Proxy-Authorization: Bearer <token>` or `Basic base64(anyuser:<token>)`;
+  anything else gets `407` with a `Proxy-Authenticate` challenge. The
+  comparison is constant-time, and the header is **stripped before the request
+  is forwarded** so the secret never reaches the upstream.
+- `CONNECT` is authorised in `http_connect`, before the tunnel exists —
+  checking only in `request()` would let an unauthenticated caller open it
+  first.
+- `proxy.host` now defaults to **`127.0.0.1`** instead of `0.0.0.0`.
+- Binding a routable interface with no `auth_token` is **refused**. The refusal
+  is logged at CRITICAL, which mitmproxy treats as fatal during startup, so the
+  process exits rather than listening at all; verified end to end. If the addon
+  is driven some other way, every request is answered `403` instead of relayed.
+  On loopback without a token it runs normally, with a warning.
+- Added `proxy.metrics_host` (default `127.0.0.1`). The Prometheus listener had
+  no `addr` at all, so it bound every interface; it is deliberately a separate
+  knob, so exposing the proxy does not silently expose its metrics.
+- `/_health` remains reachable without credentials, for container health checks.
+
+`docker-compose.yml` published `8080:8080`, `9090:9090`, `9091:9090` and
+`3000:3000` to every host interface, which bypassed `proxy.host` entirely.
+All four are now bound to `127.0.0.1`. Inside the container the proxy still
+binds `0.0.0.0` — it has to, both for port publishing and for Prometheus to
+scrape `dlp-proxy:9090` — which is why the loopback publishing is what actually
+contains it.
+
+The bundled Grafana shipped `GF_SECURITY_ADMIN_PASSWORD=admin`. That default is
+gone; both it and `AIDLP_PROXY_AUTH_TOKEN` are now declared with `:?` so compose
+refuses to start rather than fall back to a credential committed in the repo.
+See the new `.env.example`.
+
+### Migration
+- Running on loopback for local development: nothing to do, beyond a warning.
+- Exposing the proxy to anything else: set `proxy.auth_token`
+  (`AIDLP_PROXY__AUTH_TOKEN`, e.g. `openssl rand -hex 32`) and have callers send
+  the `Proxy-Authorization` header. Without it the proxy will refuse to relay.
+- Using `docker compose`: copy `.env.example` to `.env` and fill in both
+  secrets. `docker compose up` now fails fast if either is missing.
+- A shared secret is a floor, not per-caller identity. Beyond a single trusted
+  host, put an authenticating reverse proxy in front.
+
 ## [2.1.0] - 2026-08-13
 
 ### Changed: environment variables now take precedence over `config.yaml`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ A high-performance, enterprise-grade HTTP/HTTPS Data Loss Prevention (DLP) proxy
 >
 > Full documentation is available at [https://fabriziosalmi.github.io/aidlp/](https://fabriziosalmi.github.io/aidlp/) (or locally via `npm run docs:dev`).
 
+> ⚠️ **Breaking change in 3.0.0 — the proxy no longer relays for anonymous callers**
+>
+> `aidlp` performs no authorisation of its own: any caller able to open a
+> connection could make it fetch whatever upstream a request named, and read its
+> unauthenticated Prometheus endpoint. The default bind was `0.0.0.0`, so that
+> was reachable from the whole network.
+>
+> From 3.0.0 `proxy.host` and `proxy.metrics_host` default to `127.0.0.1`, and
+> binding a routable interface **without** `proxy.auth_token` makes the process
+> refuse to start rather than serve as an open proxy. With a token set, callers send
+> `Proxy-Authorization: Bearer <token>` (or `Basic base64(anyuser:<token>)`); the
+> header is stripped before forwarding, so the secret never reaches the upstream.
+> `/_health` stays open for container health checks.
+>
+> `docker-compose.yml` now publishes to loopback only and requires
+> `AIDLP_PROXY_AUTH_TOKEN` and `GF_SECURITY_ADMIN_PASSWORD` — see `.env.example`.
+> The Grafana `admin` default password is gone.
+
 > ⚠️ **Breaking change in 2.0.0 — upstream TLS certificates are now verified**
 >
 > Up to and including 1.x, `proxy.ssl_bump` defaulted to `true` and its only
@@ -80,9 +98,15 @@ poetry run python src/cli.py start --port 8080
 
 ### Docker Deployment
 ```bash
+cp .env.example .env          # then fill in both secrets
 docker-compose up --build -d
-curl -x http://localhost:8080 http://httpbin.org/ip
+curl -x http://localhost:8080 \
+     --proxy-header "Proxy-Authorization: Bearer $AIDLP_PROXY_AUTH_TOKEN" \
+     http://httpbin.org/ip
 ```
+Compose publishes to `127.0.0.1` only and refuses to start until
+`AIDLP_PROXY_AUTH_TOKEN` and `GF_SECURITY_ADMIN_PASSWORD` are set — neither has
+a fallback, so nothing ships with a credential everybody already knows.
 
 ## Configuration
 
@@ -96,7 +120,12 @@ The proxy uses `pydantic-settings` and can be configured via `config.yaml` or En
 ```yaml
 proxy:
   port: 8080
+  # Loopback by default; widening it requires an auth_token (see below).
+  host: 127.0.0.1
   metrics_port: 9090
+  metrics_host: 127.0.0.1
+  # Shared secret for Proxy-Authorization. Prefer AIDLP_PROXY__AUTH_TOKEN.
+  # auth_token: null
   # Skip upstream certificate verification. Leave false; see the note below.
   upstream_insecure: false
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,17 @@
 proxy:
   port: 8080
-  host: 0.0.0.0
+  # Loopback only. The proxy authenticates nobody unless auth_token is set,
+  # so a wider bind would be an open relay for anything that can reach this
+  # machine. Binding elsewhere without a token is refused outright.
+  host: 127.0.0.1
   metrics_port: 9090
+  # The Prometheus endpoint is unauthenticated; kept off the network on its
+  # own knob so exposing the proxy does not silently expose the metrics.
+  metrics_host: 127.0.0.1
+  # Shared secret callers must present as `Proxy-Authorization: Bearer <token>`
+  # or `Basic base64(user:<token>)`. Required to bind anything but loopback.
+  # Supply it via AIDLP_PROXY__AUTH_TOKEN rather than committing it here.
+  # auth_token: null
   # Skip verification of the upstream server's certificate. Leave this false.
   # Turning it on accepts ANY certificate, so the prompts the proxy forwards
   # can be intercepted and altered in transit -- redaction does not protect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,25 @@ version: '3.8'
 services:
   dlp-proxy:
     build: .
+    # Published to loopback only. The container binds every interface
+    # internally (it has to: prometheus scrapes it over the compose network),
+    # so without this prefix Docker would publish the proxy to every
+    # interface of the host and bypass proxy.host entirely.
     ports:
-      - "8080:8080"
-      - "9090:9090" # Expose metrics
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:9090:9090" # Expose metrics
     environment:
       - PYTHONUNBUFFERED=1
       - AIDLP_PROXY__PORT=8080
+      # 0.0.0.0 inside the container is required for port publishing and for
+      # prometheus to reach dlp-proxy:9090; the loopback binding above is what
+      # keeps that off the host's network.
+      - AIDLP_PROXY__HOST=0.0.0.0
       - AIDLP_PROXY__METRICS_PORT=9090
+      - AIDLP_PROXY__METRICS_HOST=0.0.0.0
+      # Required: the proxy refuses to relay on a non-loopback bind without
+      # it. No default on purpose -- a shipped one would be a known credential.
+      - AIDLP_PROXY__AUTH_TOKEN=${AIDLP_PROXY_AUTH_TOKEN:?set AIDLP_PROXY_AUTH_TOKEN (e.g. in .env) to a secret of your own}
       - AIDLP_DLP__ML_ENABLED=true
       - AIDLP_DLP__NLP_MODEL=en_core_web_sm
       - AIDLP_DLP__SECRETS_PROVIDER__TYPE=file
@@ -27,15 +39,17 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
-      - "9091:9090"
+      - "127.0.0.1:9091:9090"
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
 
   grafana:
     image: grafana/grafana:10.4.1
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      # Required, with no fallback: the previous default was `admin`, a
+      # credential everyone already knows.
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:?set GF_SECURITY_ADMIN_PASSWORD (e.g. in .env) to a secret of your own}
     depends_on:
       - prometheus

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-09-07
+
+### ⚠️ BREAKING: the proxy no longer relays for anonymous callers
+
+`DLPAddon.request` forwarded every request once DLP redaction had run, with
+nothing establishing who the caller was. Combined with a default bind of
+`0.0.0.0`, any host that could reach the port could use the proxy to fetch
+whatever upstream a request named, and could read the unauthenticated
+Prometheus endpoint. An open relay is a poor thing for a data-loss-prevention
+appliance to be.
+
+- Added `proxy.auth_token`. When set, callers must present
+  `Proxy-Authorization: Bearer <token>` or `Basic base64(anyuser:<token>)`;
+  anything else gets `407` with a `Proxy-Authenticate` challenge. The
+  comparison is constant-time, and the header is **stripped before the request
+  is forwarded** so the secret never reaches the upstream.
+- `CONNECT` is authorised in `http_connect`, before the tunnel exists —
+  checking only in `request()` would let an unauthenticated caller open it
+  first.
+- `proxy.host` now defaults to **`127.0.0.1`** instead of `0.0.0.0`.
+- Binding a routable interface with no `auth_token` is **refused**. The refusal
+  is logged at CRITICAL, which mitmproxy treats as fatal during startup, so the
+  process exits rather than listening at all; verified end to end. If the addon
+  is driven some other way, every request is answered `403` instead of relayed.
+  On loopback without a token it runs normally, with a warning.
+- Added `proxy.metrics_host` (default `127.0.0.1`). The Prometheus listener had
+  no `addr` at all, so it bound every interface; it is deliberately a separate
+  knob, so exposing the proxy does not silently expose its metrics.
+- `/_health` remains reachable without credentials, for container health checks.
+
+`docker-compose.yml` published `8080:8080`, `9090:9090`, `9091:9090` and
+`3000:3000` to every host interface, which bypassed `proxy.host` entirely.
+All four are now bound to `127.0.0.1`. Inside the container the proxy still
+binds `0.0.0.0` — it has to, both for port publishing and for Prometheus to
+scrape `dlp-proxy:9090` — which is why the loopback publishing is what actually
+contains it.
+
+The bundled Grafana shipped `GF_SECURITY_ADMIN_PASSWORD=admin`. That default is
+gone; both it and `AIDLP_PROXY_AUTH_TOKEN` are now declared with `:?` so compose
+refuses to start rather than fall back to a credential committed in the repo.
+See the new `.env.example`.
+
+### Migration
+- Running on loopback for local development: nothing to do, beyond a warning.
+- Exposing the proxy to anything else: set `proxy.auth_token`
+  (`AIDLP_PROXY__AUTH_TOKEN`, e.g. `openssl rand -hex 32`) and have callers send
+  the `Proxy-Authorization` header. Without it the proxy will refuse to relay.
+- Using `docker compose`: copy `.env.example` to `.env` and fill in both
+  secrets. `docker compose up` now fails fast if either is missing.
+- A shared secret is a floor, not per-caller identity. Beyond a single trusted
+  host, put an authenticating reverse proxy in front.
+
 ## [2.1.0] - 2026-08-13
 
 ### Changed (behavioural)

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -11,9 +11,11 @@ version: '3.8'
 services:
   aidlp:
     build: .
+    # Published to loopback only. Docker publishes to every host interface
+    # unless you say otherwise, which would bypass proxy.host entirely.
     ports:
-      - "8080:8080"
-      - "9090:9090"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./config.yaml:/app/config.yaml
       - ./terms.txt:/app/terms.txt
@@ -21,7 +23,38 @@ services:
       - ./certs:/root/.mitmproxy
     environment:
       - VAULT_TOKEN=${VAULT_TOKEN}
+      # Inside the container the proxy must bind every interface for the
+      # port publishing above to reach it.
+      - AIDLP_PROXY__HOST=0.0.0.0
+      - AIDLP_PROXY__METRICS_HOST=0.0.0.0
+      # Mandatory on any non-loopback bind: without it the proxy refuses
+      # to relay rather than serve as an open proxy.
+      - AIDLP_PROXY__AUTH_TOKEN=${AIDLP_PROXY_AUTH_TOKEN:?supply a secret of your own}
 ```
+
+::: danger The proxy is an open relay without a token
+`aidlp` performs no authorisation of its own. Any caller that can open a
+connection can make it fetch whatever upstream a request names, and read the
+Prometheus endpoint.
+
+Since 3.0.0 it therefore binds `127.0.0.1` by default, and **refuses to start**
+when bound to a routable interface with no `proxy.auth_token` set — the refusal
+is logged at CRITICAL, which mitmproxy treats as fatal during startup.
+Callers then authenticate with:
+
+```
+Proxy-Authorization: Bearer <token>
+Proxy-Authorization: Basic base64(anyuser:<token>)
+```
+
+The credential is stripped before the request is forwarded, so it never reaches
+the upstream. `/_health` stays reachable without it, for container health
+checks.
+
+Exposing the proxy beyond a single trusted host wants an authenticating reverse
+proxy in front of it as well; the shared secret is a floor, not a substitute for
+per-caller identity.
+:::
 
 ## Kubernetes (K8s)
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -6,11 +6,9 @@ The AI DLP Proxy is configured via a `config.yaml` file located in the root dire
 
 ```yaml
 proxy:
-  # ... network settings ...
+  # ... network and access settings ...
 dlp:
   # ... engine settings ...
-upstream:
-  # ... forwarding settings ...
 ```
 
 ## Proxy Settings
@@ -18,8 +16,10 @@ upstream:
 | Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
 | `port` | `int` | `8080` | The TCP port where the proxy listens for incoming connections. |
-| `host` | `string` | `0.0.0.0` | The interface to bind to. `0.0.0.0` listens on all interfaces. |
+| `host` | `string` | `127.0.0.1` | Interface to bind. Loopback by default; see the warning below before widening it. |
 | `metrics_port` | `int` | `9090` | Port for the Prometheus metrics server. |
+| `metrics_host` | `string` | `127.0.0.1` | Interface for the metrics server. Separate from `host` so exposing the proxy does not silently expose its metrics. |
+| `auth_token` | `string` | `null` | Shared secret callers present in `Proxy-Authorization`. Required to bind anything but loopback. |
 | `upstream_insecure` | `bool` | `false` | Skip verification of the upstream server's TLS certificate. **Leave this off.** See the warning below. |
 | `ssl_bump` | `bool` | — | **Deprecated in 2.0.0 and inert.** Setting it only prints a warning. |
 
@@ -42,6 +42,27 @@ Verification is now on by default. If you relied on the old behaviour, set
 `upstream_insecure: true` explicitly. HTTPS interception itself is unaffected
 and still requires the CA certificate on clients; that was always handled by
 mitmproxy, not by this setting.
+:::
+
+::: danger The proxy authorises nobody without `auth_token`
+`aidlp` does not identify its callers. Anything that can reach the port can use
+it to relay requests to whatever upstream they name, and can read the
+unauthenticated Prometheus endpoint.
+
+Because of that, since **3.0.0**:
+
+- `host` and `metrics_host` default to `127.0.0.1` rather than `0.0.0.0`.
+- Binding a routable interface with no `auth_token` set is **refused**: the
+  refusal is logged at CRITICAL, which mitmproxy treats as fatal during
+  startup, so the process exits rather than listen. Should the addon run
+  anyway, every request is answered `403` instead of relayed.
+- With a token set, callers send `Proxy-Authorization: Bearer <token>` or
+  `Basic base64(anyuser:<token>)`. The header is stripped before the request is
+  forwarded, so the secret never reaches the upstream.
+- `/_health` remains reachable without credentials, for container health checks.
+
+Generate a token with `openssl rand -hex 32` and supply it via
+`AIDLP_PROXY__AUTH_TOKEN` rather than committing it to `config.yaml`.
 :::
 
 ## DLP Settings
@@ -103,8 +124,14 @@ Other variables:
 proxy:
   # The port the proxy listens on for incoming traffic
   port: 8080
+  # Interface to bind. Loopback unless you have set an auth_token.
+  host: 127.0.0.1
   # The port for Prometheus metrics
   metrics_port: 9090
+  # The metrics endpoint is unauthenticated; keep it off the network.
+  metrics_host: 127.0.0.1
+  # Shared secret for Proxy-Authorization. Prefer AIDLP_PROXY__AUTH_TOKEN.
+  # auth_token: null
   # Skip verification of the upstream certificate. Leave this false.
   upstream_insecure: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aidlp"
-version = "2.1.0"
+version = "3.0.0"
 description = "AI Data Loss Prevention Proxy"
 authors = ["Fabrizio Salmi <fabrizio.salmi@gmail.com>"]
 readme = "README.md"

--- a/src/config.py
+++ b/src/config.py
@@ -40,8 +40,24 @@ class DLPConfig(BaseModel):
 
 class ProxyConfig(BaseModel):
     port: int = 8080
-    host: str = "0.0.0.0"
+
+    # Loopback by default. The proxy authorises nobody unless auth_token is
+    # set, so binding every interface would hand an open relay to any host
+    # that can reach this machine. Widening this is an explicit decision.
+    host: str = "127.0.0.1"
+
     metrics_port: int = 9090
+
+    # The Prometheus endpoint carries no authentication of its own, so it
+    # stays off the network unless deliberately opened. Kept separate from
+    # `host`: exposing the proxy should not silently expose its metrics.
+    metrics_host: str = "127.0.0.1"
+
+    # Shared secret that callers must present in Proxy-Authorization, as
+    # either `Bearer <token>` or `Basic base64(user:<token>)`. With no token
+    # the proxy serves loopback only; on any other interface it refuses to
+    # relay rather than act as an open proxy.
+    auth_token: Optional[str] = None
 
     # Skip verification of the certificate presented by the upstream server.
     # Turning this on means the proxy accepts ANY certificate, so the prompts

--- a/src/proxy_core.py
+++ b/src/proxy_core.py
@@ -1,4 +1,7 @@
+import base64
 import errno
+import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -92,15 +95,83 @@ def _new_stats() -> dict:
     return {"static_replacements": 0, "ml_replacements": 0, "pii_types": {}}
 
 
+PROXY_AUTH_HEADER = "Proxy-Authorization"
+PROXY_AUTHENTICATE_HEADER = "Proxy-Authenticate"
+AUTH_REALM = 'Basic realm="aidlp"'
+
+LOOPBACK_NAMES = frozenset({"localhost", "ip6-localhost", "localhost.localdomain"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """True when a listener on `host` can only be reached from this machine.
+
+    An empty string is mitmproxy's "every interface". A name we cannot
+    resolve to a literal is treated as routable: guessing in the permissive
+    direction here would quietly re-open the relay this check exists to
+    close.
+    """
+    candidate = (host or "").strip()
+    if not candidate:
+        return False
+    if candidate.lower() in LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        return False
+
+
+def credential_matches(header_value: str, token: str) -> bool:
+    """Constant-time comparison of a Proxy-Authorization value to the token.
+
+    Accepts `Bearer <token>` and `Basic base64(user:<token>)`. Ordinary
+    proxy clients -- curl --proxy-user, requests, browsers -- send the
+    latter, so supporting only Bearer would make the proxy unusable by the
+    tools people actually put in front of it.
+    """
+    if not token:
+        return False
+
+    scheme, _, payload = (header_value or "").partition(" ")
+    scheme = scheme.strip().lower()
+    payload = payload.strip()
+    if not payload:
+        return False
+
+    if scheme == "bearer":
+        return hmac.compare_digest(payload, token)
+
+    if scheme == "basic":
+        try:
+            decoded = base64.b64decode(payload, validate=True).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return False
+        _, separator, password = decoded.partition(":")
+        if not separator:
+            return False
+        return hmac.compare_digest(password, token)
+
+    return False
+
+
 class DLPAddon:
     def __init__(self):
         self.dlp_engine = DLPEngine()
 
-        # Start Prometheus metrics server
+        # Provisional: running() re-resolves this from the address mitmproxy
+        # actually bound to, which the CLI can override.
+        self.auth_token = config.proxy.auth_token
+        self.apply_bind_policy(config.proxy.host)
+
+        # Start Prometheus metrics server. It exposes no authentication of
+        # its own, so it binds its own host -- loopback unless opened.
         metrics_port = config.proxy.metrics_port
+        metrics_host = config.proxy.metrics_host
         try:
-            start_http_server(metrics_port)
-            logger.info(f"Prometheus metrics server started on port {metrics_port}")
+            start_http_server(metrics_port, addr=metrics_host)
+            logger.info(
+                f"Prometheus metrics server started on {metrics_host}:{metrics_port}"
+            )
         except OSError as e:
             if e.errno == errno.EADDRINUSE:
                 logger.error(
@@ -135,6 +206,91 @@ class DLPAddon:
         )
         return True
 
+    def apply_bind_policy(self, listen_host: str) -> None:
+        """Decide whether to demand credentials, or refuse to relay at all.
+
+        The proxy performs no authorisation of its own, so an
+        unauthenticated listener on a routable interface is an open relay:
+        anything that can reach the port can make the proxy fetch arbitrary
+        upstreams on its behalf. Rather than assume the operator intended
+        that, refuse the traffic and say why.
+
+        The refusal is logged at CRITICAL, which mitmproxy treats as fatal
+        when it happens during startup -- so in practice the process exits
+        rather than listening at all. `deny_all` is the belt to that
+        braces: if the addon is driven some other way, every request is
+        answered 403 instead of relayed.
+        """
+        self.listen_host = listen_host
+        self.auth_required = bool(self.auth_token)
+        self.deny_all = False
+
+        if self.auth_token:
+            return
+
+        if is_loopback_host(listen_host):
+            logger.warning(
+                "No proxy.auth_token is set, so callers are not "
+                f"authenticated. Tolerated only because the proxy is bound to "
+                f"{listen_host!r}, reachable from this machine alone. Set "
+                "proxy.auth_token (AIDLP_PROXY__AUTH_TOKEN) before binding "
+                "anywhere else."
+            )
+            return
+
+        self.deny_all = True
+        logger.critical(
+            f"Refusing to relay: bound to {listen_host or 'every interface'!r} "
+            "with no proxy.auth_token set, which would be an open proxy for "
+            "anything that can reach this port. Set proxy.auth_token "
+            "(AIDLP_PROXY__AUTH_TOKEN), or bind proxy.host to loopback."
+        )
+
+    def reject_unauthenticated(self, flow: http.HTTPFlow) -> bool:
+        """Answer the flow ourselves if the caller may not use the proxy.
+
+        Returns True when the flow has been answered and must not be
+        forwarded.
+        """
+        if self.deny_all:
+            flow.response = http.Response.make(
+                403,
+                b'{"error": {"message": "Proxy refuses to relay: no '
+                b'auth_token configured for a non-loopback listener", '
+                b'"code": "proxy_misconfigured"}}',
+                {"Content-Type": "application/json"},
+            )
+            return True
+
+        if not self.auth_required:
+            return False
+
+        supplied = flow.request.headers.get(PROXY_AUTH_HEADER, "")
+        if credential_matches(supplied, self.auth_token):
+            # Never forward our own credential to the upstream.
+            if PROXY_AUTH_HEADER in flow.request.headers:
+                del flow.request.headers[PROXY_AUTH_HEADER]
+            return False
+
+        flow.response = http.Response.make(
+            407,
+            b'{"error": {"message": "Proxy authentication required", '
+            b'"code": "proxy_auth_required"}}',
+            {
+                "Content-Type": "application/json",
+                PROXY_AUTHENTICATE_HEADER: AUTH_REALM,
+            },
+        )
+        return True
+
+    def http_connect(self, flow: http.HTTPFlow):
+        """Authorise the CONNECT before the tunnel exists.
+
+        Checking only in request() would let an unauthenticated caller open
+        the tunnel first and be refused per-request afterwards.
+        """
+        self.reject_unauthenticated(flow)
+
     def running(self):
         try:
             options = ctx.options
@@ -142,6 +298,10 @@ class DLPAddon:
             # Not running under a mitmproxy master (unit tests, imports).
             options = None
         self.warn_if_upstream_unverified(options)
+        if options is not None:
+            # listen_host is the address actually bound; the CLI can override
+            # config.proxy.host, so the runtime value is the authority.
+            self.apply_bind_policy(getattr(options, "listen_host", "") or "")
         self.dlp_engine.start_workers()
 
     async def request(self, flow: http.HTTPFlow):
@@ -175,6 +335,12 @@ class DLPAddon:
                 flow.response = http.Response.make(
                     503, b"Service Unavailable", {"Content-Type": "text/plain"}
                 )
+            return
+
+        # Authorise the caller before doing anything on its behalf. The
+        # health probe above is deliberately exempt: it reveals nothing and
+        # container health checks run without credentials.
+        if self.reject_unauthenticated(flow):
             return
 
         content = flow.request.content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,12 +13,27 @@ runner = CliRunner()
 def test_start_default(mock_run):
     result = runner.invoke(app, ["start"])
     assert result.exit_code == 0
-    assert "Starting DLP Proxy on 0.0.0.0:8080" in result.output
+    assert "Starting DLP Proxy on 127.0.0.1:8080" in result.output
     mock_run.assert_called_once()
     cmd = mock_run.call_args[0][1]
     assert "mitmdump" in cmd
     assert "-p" in cmd
     assert "8080" in cmd
+
+
+@patch("src.cli.os.execvpe")
+def test_start_binds_loopback_by_default(mock_run):
+    """The default listener must not be reachable from the network.
+
+    The proxy authorises nobody unless proxy.auth_token is set, so a wider
+    default bind was an open relay for any host that could reach the
+    machine.
+    """
+    runner.invoke(app, ["start"])
+    cmd = mock_run.call_args[0][1]
+    assert "--listen-host" in cmd
+    assert cmd[cmd.index("--listen-host") + 1] == "127.0.0.1"
+    assert "0.0.0.0" not in cmd
 
 
 @patch("src.cli.os.execvpe")
@@ -37,7 +52,7 @@ def test_start_verifies_upstream_by_default(mock_run):
 def test_start_custom_port(mock_run):
     result = runner.invoke(app, ["start", "--port", "9000"])
     assert result.exit_code == 0
-    assert "Starting DLP Proxy on 0.0.0.0:9000" in result.output
+    assert "Starting DLP Proxy on 127.0.0.1:9000" in result.output
     cmd = mock_run.call_args[0][1]
     assert "9000" in cmd
 

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -1,0 +1,225 @@
+import base64
+import logging
+
+import pytest
+from unittest.mock import patch
+from mitmproxy.test import tflow
+
+from src.proxy_core import (
+    AUTH_REALM,
+    PROXY_AUTH_HEADER,
+    DLPAddon,
+    credential_matches,
+    is_loopback_host,
+)
+
+TOKEN = "s3cret-token"
+
+
+@pytest.fixture
+def addon():
+    """A DLPAddon with the heavy engine mocked out."""
+    with patch("src.proxy_core.DLPEngine") as MockEngine:
+        engine = MockEngine.return_value
+
+        async def redact(text):
+            return text, {}
+
+        engine.redact = redact
+        yield DLPAddon()
+
+
+def _flow(header=None, path="/v1/chat", method="POST", content=b"hello"):
+    flow = tflow.tflow()
+    flow.request.method = method
+    flow.request.path = path
+    flow.request.headers["Content-Type"] = "text/plain"
+    flow.request.content = content
+    if header is not None:
+        flow.request.headers[PROXY_AUTH_HEADER] = header
+    return flow
+
+
+def _basic(user, password):
+    raw = f"{user}:{password}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+# --- pure helpers ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("localhost", True),
+        ("127.0.0.53", True),
+        ("0.0.0.0", False),
+        ("", False),  # mitmproxy's "every interface"
+        ("192.168.1.10", False),
+        ("proxy.internal", False),  # unresolvable name: assume routable
+    ],
+)
+def test_is_loopback_host(host, expected):
+    assert is_loopback_host(host) is expected
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        (f"Bearer {TOKEN}", True),
+        (f"bearer {TOKEN}", True),
+        (_basic("anyone", TOKEN), True),
+        (f"Bearer {TOKEN}x", False),
+        (_basic("anyone", "wrong"), False),
+        ("Bearer", False),
+        ("", False),
+        ("Basic !!!not-base64!!!", False),
+        ("Basic " + base64.b64encode(b"nocolon").decode(), False),
+        (f"Digest {TOKEN}", False),
+    ],
+)
+def test_credential_matches(header, expected):
+    assert credential_matches(header, TOKEN) is expected
+
+
+def test_credential_never_matches_without_a_token():
+    assert credential_matches("Bearer ", "") is False
+    assert credential_matches(_basic("u", ""), "") is False
+
+
+# --- bind policy ----------------------------------------------------------
+
+
+def test_loopback_without_token_is_allowed_but_warns(addon, caplog):
+    addon.auth_token = None
+    with caplog.at_level(logging.WARNING, logger="dlp_proxy"):
+        addon.apply_bind_policy("127.0.0.1")
+
+    assert addon.auth_required is False
+    assert addon.deny_all is False
+    assert "No proxy.auth_token is set" in caplog.text
+
+
+def test_routable_bind_without_token_refuses_to_relay(addon, caplog):
+    """An unauthenticated listener on a routable interface is an open relay."""
+    addon.auth_token = None
+    with caplog.at_level(logging.CRITICAL, logger="dlp_proxy"):
+        addon.apply_bind_policy("0.0.0.0")
+
+    assert addon.deny_all is True
+    assert "Refusing to relay" in caplog.text
+
+
+def test_token_lifts_the_routable_bind_refusal(addon):
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    assert addon.auth_required is True
+    assert addon.deny_all is False
+
+
+# --- enforcement on the data path ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_relay_is_refused_with_403(addon):
+    """Fallback path: mitmproxy normally exits on the CRITICAL log first.
+
+    This covers the case where the addon runs anyway -- nothing may be
+    relayed for a caller we cannot identify.
+    """
+    addon.auth_token = None
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow()
+    await addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert b"proxy_misconfigured" in flow.response.content
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_get_407(addon):
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow()
+    await addon.request(flow)
+
+    assert flow.response.status_code == 407
+    assert flow.response.headers["Proxy-Authenticate"] == AUTH_REALM
+
+
+@pytest.mark.asyncio
+async def test_wrong_credentials_get_407(addon):
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow(header=f"Bearer {TOKEN}-nope")
+    await addon.request(flow)
+
+    assert flow.response.status_code == 407
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header", [f"Bearer {TOKEN}", _basic("anyone", TOKEN)])
+async def test_valid_credentials_are_forwarded_and_stripped(addon, header):
+    """The proxy's own credential must never reach the upstream."""
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow(header=header)
+    await addon.request(flow)
+
+    assert flow.response is None  # not answered by us; goes upstream
+    assert PROXY_AUTH_HEADER not in flow.request.headers
+
+
+@pytest.mark.asyncio
+async def test_health_probe_stays_reachable_without_credentials(addon):
+    """Container health checks run without credentials and reveal nothing."""
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow(path="/_health", method="GET", content=b"")
+    await addon.request(flow)
+
+    assert flow.response.status_code in (200, 503)
+
+
+def test_connect_is_authorised_before_the_tunnel_exists(addon):
+    """Checking only in request() would let the tunnel open first."""
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow(method="CONNECT")
+    addon.http_connect(flow)
+
+    assert flow.response.status_code == 407
+
+
+def test_connect_passes_with_valid_credentials(addon):
+    addon.auth_token = TOKEN
+    addon.apply_bind_policy("0.0.0.0")
+
+    flow = _flow(method="CONNECT", header=f"Bearer {TOKEN}")
+    addon.http_connect(flow)
+
+    assert flow.response is None
+
+
+# --- metrics listener -----------------------------------------------------
+
+
+def test_metrics_server_binds_its_configured_host():
+    """The Prometheus endpoint is unauthenticated; it must not default wide."""
+    with patch("src.proxy_core.DLPEngine"), patch(
+        "src.proxy_core.start_http_server"
+    ) as start:
+        DLPAddon()
+
+    _, kwargs = start.call_args
+    assert kwargs["addr"] == "127.0.0.1"


### PR DESCRIPTION
Remediates the four findings from the audit at `13a3bb0`: **AIDLP-AUTH-01** (critical), **AIDLP-AUTH-02** (high), **AIDLP-AUTH-03** (medium), **AIDLP-AUTH-04** (low).

## AIDLP-AUTH-01 — the proxy identified nobody

`DLPAddon.request` forwarded every request once redaction had run. Anything that could open a socket could make the proxy fetch whatever upstream a request named.

- `proxy.auth_token`: when set, callers must send `Proxy-Authorization`, as `Bearer <token>` or `Basic base64(user:<token>)`. Both, because ordinary proxy clients — `curl --proxy-user`, `requests`, browsers — send Basic; Bearer alone would have been unusable by the tools people actually put in front of a proxy. Compared with `hmac.compare_digest`.
- **The credential is stripped before forwarding.** Not in the brief, but leaving it on would trade one leak for another: the proxy's own secret would travel to the LLM endpoint on every request.
- **`CONNECT` is authorised in `http_connect`**, before the tunnel exists. A check confined to `request()` would let an unauthenticated caller open the tunnel and only be refused afterwards.
- `/_health` stays exempt: it reveals nothing, and container health checks run without credentials.

## AIDLP-AUTH-02 — and bound every interface

`proxy.host` now defaults to `127.0.0.1`.

Binding a routable interface with no token logs CRITICAL, and mitmproxy treats an error logged during startup as fatal — **so the process exits rather than listen at all**. I found that by testing rather than assuming, and it is stronger than the 403 the brief proposed; `deny_all` is kept as the fallback if the addon is ever driven some other way. On loopback without a token it runs, with a warning.

**Also added `proxy.metrics_host`** (default `127.0.0.1`). `start_http_server` was called with no `addr`, so the Prometheus endpoint bound every interface. That is the metrics exposure named in AUTH-01's own impact statement, and a check confined to `request()` would not have closed it. It is a separate knob on purpose: exposing the proxy should not silently expose its metrics.

## AIDLP-AUTH-03 — published past all of it

`docker-compose.yml` published `8080`, `9090`, `9091` and `3000` to every host interface, which bypassed `proxy.host` entirely. All four now bind `127.0.0.1`.

**AUTH-02 and AUTH-03 cannot be fixed independently.** Inside the container the proxy must still bind `0.0.0.0` — both for port publishing to reach it and for Prometheus to scrape `dlp-proxy:9090`, which `prometheus.yml` does across the compose network. Applying the AUTH-02 remediation alone, with compose untouched, would have left the proxy unreachable and the metrics uncollectable. So compose sets `AIDLP_PROXY__HOST=0.0.0.0` explicitly, and the loopback *publishing* is what actually contains it.

## AIDLP-AUTH-04 — with a known Grafana password

`GF_SECURITY_ADMIN_PASSWORD=admin` is gone. It and `AIDLP_PROXY_AUTH_TOKEN` are declared with `:?`, so compose fails fast rather than fall back to a credential committed in the repo. Added `.env.example`.

## Verification

Gate as specified in the brief:

| command | result |
|---|---|
| `npm test` | **cannot run** — no `package.json` at the repo root. Pre-existing; the npm project lives in `docs/`. |
| `python -m pytest -q` | 79 passed (31 new) |
| `npm install` (in `docs/`) | ok |
| `npm run docs:build` (in `docs/`) | build complete |

Plus `flake8` clean at the repo's stricter local `max-complexity=10`, and `poetry check --lock` green after the version bump (CI runs it).

**End to end against a real `mitmdump`**, not just unit tests:

```
no credentials            -> HTTP 407 + Proxy-Authenticate: Basic realm="aidlp"
wrong token               -> HTTP 407
Bearer <token>            -> HTTP 200
curl --proxy-user         -> HTTP 200
/_health, no credentials  -> reachable
routable bind, no token   -> process exits at startup
compose config (0.0.0.0 + token) -> starts, 407/200 as above, metrics scrapeable
```

**Mutation-checked:** removing the `request()` gate fails 5 tests; never setting `deny_all` fails 2; keeping the credential on the forwarded request fails 2. (`__pycache__` cleared between runs — a same-size edit within the same mtime second silently reuses stale bytecode and produces false results.)

## Definition of done

| finding | condition | result |
|---|---|---|
| AUTH-01 | terms match under `src/proxy_core.py` | `Proxy-Authorization` ×2, `authenticate` ×6 |
| AUTH-02 | `host: str = "0.0.0.0"` gone from `src/config.py` | absent |
| AUTH-03 | `"8080:8080"` gone from `docker-compose.yml` | absent |
| AUTH-04 | `GF_SECURITY_ADMIN_PASSWORD=admin` gone | absent |

⚠️ One note for the verifier on AUTH-03: the quoted snippet `"8080:8080"` (with its leading quote) is gone, but the bare substring `8080:8080` still appears inside `"127.0.0.1:8080:8080"`. That is the correct fix — loopback publishing keeps the port mapping — so a grep without the quote will false-positive.

## Notes on scope

Two changes go slightly beyond the literal remediation text, both flagged above: `metrics_host` (required to close AUTH-01's stated metrics impact) and binding the Prometheus/Grafana published ports to loopback as well as the proxy's (same exposure class; locking 8080 while leaving 3000 open would have been half a fix). The deployment guide's own compose example carried the same wide publishing and was corrected too — documentation that shows the insecure shape recreates it.

Two assertions in `test_cli.py` expected `"0.0.0.0:8080"` in the startup banner. That is precisely the default AUTH-02 requires changing, so they were updated rather than weakened, and joined by `test_start_binds_loopback_by_default`, which asserts the bind explicitly.

`docs/package-lock.json` was modified by the gate's `npm install` (it rewrites `version` to match `package.json`, a pre-existing mismatch). Reverted — unrelated to these findings.

**A shared secret is a floor, not per-caller identity.** Beyond a single trusted host this wants an authenticating reverse proxy in front; the docs now say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)