### PR TITLE
fix: close the five findings the earlier sweeps had not seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ dlp:
   static_terms_file: "terms.txt"
   ml_enabled: true
   nlp_model: "en_core_web_sm"
+  # Forward with static-only redaction when the ML stage times out, instead of
+  # failing the request closed. Off by default: partial redaction is a real
+  # reduction in coverage, so it has to be a deliberate choice.
+  degrade_to_static_on_ml_timeout: false
   secrets_provider:
     type: "vault"
     vault:
@@ -183,12 +187,40 @@ have gone stale, the Vault circuit breaker is open, the ML worker pool is dead,
 or the term poller stopped. It is covered by the same compatibility policy as
 the CLI flags.
 
-- `dlp_requests_total`: Total requests processed.
-- `dlp_redacted_total`: Requests containing sensitive data.
-- `dlp_pii_detected_total`: Count of PII entities by type (e.g., `PERSON`).
-- `dlp_active_connections`: Current active connections.
+### Metrics
 
-Logs are printed in structured JSON format to stdout.
+Traffic:
+
+- `dlp_flows_seen_total`: Every request the proxy saw, inspected or not.
+- `dlp_requests_total`: Requests that reached DLP processing.
+- `dlp_redacted_total`: Requests in which something was redacted.
+- `dlp_pii_detected_total{type}`: PII entities found, by type (e.g. `PERSON`).
+- `dlp_active_connections`: Requests currently in flight.
+- `dlp_latency_seconds`: Histogram of time spent in DLP processing.
+- `dlp_token_usage_total{direction}`: Estimated tokens in and out.
+
+Term-source health — these are what an alert on "redaction terms have gone
+stale" should be built from:
+
+- `dlp_term_reload_failures_total{source}`: Failed term refreshes.
+- `dlp_terms_last_reload_success_timestamp_seconds`: Unix time of the last
+  successful load. Alert on its age.
+- `dlp_term_poller_alive`: `1` while the refresh poller is running.
+
+ML pool health:
+
+- `dlp_ml_workers_alive`: Live ML worker tasks.
+- `dlp_ml_worker_restarts_total`: Workers replaced after exceeding the hard
+  analysis ceiling.
+- `dlp_ml_degraded_total`: Requests forwarded with static-only redaction after
+  an ML timeout. Non-zero only if `dlp.degrade_to_static_on_ml_timeout` is on.
+
+`aidlp stats` surfaces a subset of these (requests, redactions, PII entities,
+active connections); the full set is on the metrics port.
+
+Logs are printed in structured JSON format to stdout, and carry the
+`X-Request-ID` correlation identifier, which is also threaded into the DLP
+engine so an ML failure names the request that caused it.
 
 ## License
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -135,16 +135,29 @@ def stats():
 
     # Parse simple metrics using regex
     def get_metric(name):
-        match = re.search(f"^{name} ([\\d\\.]+)", metrics, re.MULTILINE)
+        match = re.search(f"^{re.escape(name)} ([\\d\\.eE+-]+)", metrics, re.MULTILINE)
         return float(match.group(1)) if match else 0
+
+    def sum_labelled_metric(name):
+        """Sum a labelled counter across its label values.
+
+        dlp_pii_detected_total is emitted per type, as
+        `dlp_pii_detected_total{type="PERSON"} 3.0`, so the unlabelled
+        pattern above never matches it -- which is why it was missing from
+        this command despite README listing it.
+        """
+        pattern = rf"^{re.escape(name)}\{{[^}}]*\}} ([\d\.eE+-]+)"
+        return sum(float(v) for v in re.findall(pattern, metrics, re.MULTILINE))
 
     total_requests = get_metric("dlp_requests_total")
     redacted_requests = get_metric("dlp_redacted_total")
     active_connections = get_metric("dlp_active_connections")
+    pii_detected = sum_labelled_metric("dlp_pii_detected_total")
 
     typer.echo("DLP Proxy Stats (Prometheus):")
     typer.echo(f"  Total Requests: {int(total_requests)}")
     typer.echo(f"  Redacted Requests: {int(redacted_requests)}")
+    typer.echo(f"  PII Entities Detected: {int(pii_detected)}")
     typer.echo(f"  Active Connections: {int(active_connections)}")
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,10 @@ class VaultConfig(BaseModel):
     model_config = _STRICT
 
     url: str = "http://localhost:8200"
+    # Bounds the HTTP call itself. The circuit breaker counts *failures*, so a
+    # Vault that is slow but not yet erroring could stall a fetch without ever
+    # incrementing the failure count that would open the breaker.
+    timeout: float = Field(10.0, gt=0)
     token: Optional[str] = None
     path: str = "aidlp/terms"
 
@@ -64,6 +68,11 @@ class DLPConfig(BaseModel):
     # Applies to the file provider as well as Vault, so `aidlp add-term`
     # reaches a running proxy without a restart.
     reload_interval: float = 60.0
+    # When only the ML stage times out, forward with static-keyword redaction
+    # instead of failing the request closed. OFF by default: partial redaction
+    # is a real reduction in coverage, and for a DLP proxy that has to be a
+    # deliberate choice rather than a default.
+    degrade_to_static_on_ml_timeout: bool = False
     # ML analysis capacity. Previously literals in dlp_engine.py, so the only
     # way to add workers or deepen the queue was to edit the source.
     ml_workers: int = Field(4, ge=1, le=64)

--- a/src/dlp_engine.py
+++ b/src/dlp_engine.py
@@ -35,6 +35,10 @@ TERM_POLLER_ALIVE = Gauge(
 
 # ML pool health.
 ML_WORKERS_ALIVE = Gauge("dlp_ml_workers_alive", "Live ML worker tasks")
+ML_DEGRADED_TOTAL = Counter(
+    "dlp_ml_degraded_total",
+    "Requests forwarded with static-only redaction after an ML timeout",
+)
 ML_WORKER_RESTARTS = Counter(
     "dlp_ml_worker_restarts_total",
     "ML workers replaced after exceeding the hard analysis ceiling",
@@ -170,8 +174,15 @@ class FileTermProvider(TermProvider):
 
 
 class VaultTermProvider(TermProvider):
-    def __init__(self, url: str, token: str, path: str, mount_point: str = "secret"):
-        self.client = hvac.Client(url=url, token=token)
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        path: str,
+        mount_point: str = "secret",
+        timeout: float = 10.0,
+    ):
+        self.client = hvac.Client(url=url, token=token, timeout=timeout)
         self.path = path
         self.mount_point = mount_point
         self.breaker = pybreaker.CircuitBreaker(fail_max=3, reset_timeout=60)
@@ -454,7 +465,7 @@ class DLPEngine:
             if not (vault_cfg.url and token and vault_cfg.path):
                 raise TermFetchError("Vault configuration incomplete (url/token/path)")
             self._term_provider = VaultTermProvider(
-                vault_cfg.url, token, vault_cfg.path
+                vault_cfg.url, token, vault_cfg.path, timeout=vault_cfg.timeout
             )
         else:
             self._term_provider = FileTermProvider(self.config.static_terms_file)
@@ -555,7 +566,22 @@ class DLPEngine:
             stats["static_replacements"] += 1
 
         if self.ml_enabled and self.analyzer:
-            await self._analyze_ml(text, spans, stats, request_id)
+            try:
+                await self._analyze_ml(text, spans, stats, request_id)
+            except asyncio.TimeoutError:
+                if not self.config.degrade_to_static_on_ml_timeout:
+                    raise
+                # Explicitly enabled: forward with reduced coverage rather
+                # than block. Recorded in the stats and the metrics so the
+                # degradation is never invisible.
+                stats["ml_degraded"] = True
+                ML_DEGRADED_TOTAL.inc()
+                logger.warning(
+                    "ML analysis timed out; forwarding with static-keyword "
+                    "redaction only (degrade_to_static_on_ml_timeout is on). "
+                    "Detection coverage is reduced for this request.",
+                    extra={"request_id": request_id},
+                )
 
         if not spans:
             return text, stats

--- a/src/proxy_core.py
+++ b/src/proxy_core.py
@@ -5,12 +5,30 @@ import ipaddress
 import json
 import logging
 import os
-from mitmproxy import ctx, http
-from src import __version__ as AIDLP_VERSION
-from src.dlp_engine import DLPEngine
-from src.config import config
-from prometheus_client import start_http_server, Counter, Histogram, Gauge
-from pythonjsonlogger import jsonlogger
+import sys
+from pathlib import Path
+
+# mitmdump loads this file by path, so `from src...` below resolved only
+# because cli.py sets PYTHONPATH before exec'ing it. Driving mitmdump
+# directly -- which the deployment guide does -- bypasses that, and the
+# import fails before the addon is ever constructed. Make the file
+# self-sufficient rather than depend on a side effect from an optional
+# module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from mitmproxy import ctx, http  # noqa: E402
+from src import __version__ as AIDLP_VERSION  # noqa: E402
+from src.dlp_engine import DLPEngine  # noqa: E402
+from src.config import config  # noqa: E402
+from prometheus_client import (  # noqa: E402
+    start_http_server,
+    Counter,
+    Histogram,
+    Gauge,
+)
+from pythonjsonlogger import jsonlogger  # noqa: E402
 
 # Configure JSON logging
 logger = logging.getLogger("dlp_proxy")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -218,3 +218,93 @@ def test_missing_terms_file_is_announced(tmp_path, caplog):
 
     assert terms == list(FileTermProvider.DEFAULT_TERMS)
     assert "placeholder terms" in caplog.text
+
+
+# --- degraded mode is opt-in, and never silent -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ml_timeout_fails_closed_by_default():
+    """The default must stay fail-closed: partial redaction is a real
+    reduction in coverage."""
+    engine = DLPEngine(dlp_config=DLPConfig(ml_enabled=False))
+    engine.ml_enabled = True
+    engine.analyzer = object()
+    engine.ml_timeout = 0.05
+
+    with pytest.raises(asyncio.TimeoutError):
+        await engine.redact("some text")
+
+
+@pytest.mark.asyncio
+async def test_ml_timeout_can_degrade_to_static_when_enabled(caplog):
+    engine = DLPEngine(
+        dlp_config=DLPConfig(
+            ml_enabled=False, degrade_to_static_on_ml_timeout=True
+        )
+    )
+    engine.ml_enabled = True
+    engine.analyzer = object()
+    engine.ml_timeout = 0.05
+    engine.keyword_processor.add_keyword("alpha", "alpha")
+
+    with caplog.at_level(logging.WARNING, logger="dlp_proxy"):
+        redacted, stats = await engine.redact("alpha and more")
+
+    assert "[REDACTED]" in redacted          # static coverage still applied
+    assert stats["ml_degraded"] is True      # and the degradation is recorded
+    assert "Detection coverage is reduced" in caplog.text
+
+
+# --- the Vault call itself is bounded ----------------------------------------
+
+
+def test_vault_client_is_given_a_timeout():
+    """The breaker counts failures; a slow-but-not-erroring Vault could stall
+    a fetch without ever incrementing that count."""
+    from src.dlp_engine import VaultTermProvider
+
+    with patch("src.dlp_engine.hvac.Client") as MockClient:
+        VaultTermProvider("http://v:8200", "tok", "p", timeout=3.5)
+
+    assert MockClient.call_args.kwargs["timeout"] == 3.5
+
+
+# --- stats reports what the README promises ----------------------------------
+
+
+def test_stats_sums_the_labelled_pii_counter():
+    """dlp_pii_detected_total is emitted per type, so the unlabelled pattern
+    the CLI used never matched it."""
+    from typer.testing import CliRunner
+    from src.cli import app
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.text = (
+        "dlp_requests_total 42.0\n"
+        "dlp_redacted_total 7.0\n"
+        "dlp_active_connections 3.0\n"
+        'dlp_pii_detected_total{type="PERSON"} 3.0\n'
+        'dlp_pii_detected_total{type="EMAIL_ADDRESS"} 2.0\n'
+    )
+
+    with patch("src.cli.requests.get", return_value=response):
+        result = CliRunner().invoke(app, ["stats"])
+
+    assert "PII Entities Detected: 5" in result.output
+
+
+# --- the composition root resolves its own imports ---------------------------
+
+
+def test_proxy_core_puts_the_repo_root_on_sys_path():
+    """It used to rely on cli.py exporting PYTHONPATH before exec'ing
+    mitmdump, which driving mitmdump directly bypasses."""
+    import sys
+    from pathlib import Path
+
+    import src.proxy_core as proxy_core
+
+    repo_root = Path(proxy_core.__file__).resolve().parent.parent
+    assert str(repo_root) in sys.path


### PR DESCRIPTION
The six follow-up briefs overlap almost entirely with work already on `main`. I verified all of it mechanically before writing any code: **50 of the 56 previously visible findings are resolved, 4 are blocked upstream and tracked, and 2 that my own check flagged were false negatives in the check, not regressions** (`done()` does call `shutdown()` — my `grep -A9` did not reach past the docstring; the only `install.python-poetry.org` match is a comment explaining why we no longer use it).

Five findings in the new briefs were genuinely unaddressed.

## ARCH-04 — the composition root could not import itself

`proxy_core.py` resolved `from src...` only because `cli.py` exports `PYTHONPATH` before exec'ing mitmdump. Driving mitmdump directly — which `docs/guide/deployment.md` does, and which the file's own comment acknowledges — bypasses that, and the import fails *before* `DLPAddon` is ever constructed.

It now puts its own repo root on `sys.path`. Verified by importing it from `/tmp` with no `PYTHONPATH` set: previously an `ImportError`, now it loads.

## REL-05 — a degraded mode, off by default

Added `dlp.degrade_to_static_on_ml_timeout`. When an ML timeout is the *only* failure, the request can be forwarded with the static-keyword redaction that already completed, rather than blocked entirely.

**Deliberately off by default.** The finding itself hedged — *"if acceptable for the threat model"* — and for a DLP proxy, quietly reducing detection coverage is not something to default into. When enabled, the degradation is recorded in the request stats, counted on `dlp_ml_degraded_total`, and logged with the request id, so it is never invisible.

## REL-06 — where I did not follow the stated condition

The finding is a **positive** one: it praises the circuit breaker. Its resolution condition nonetheless says *"the quoted snippet is no longer present at `src/dlp_engine.py`"* — the quoted snippet being the breaker's construction. Satisfying that literally would mean **deleting the control the finding commends**. I did not.

I implemented the actionable half instead: `vault.timeout` (default 10s) now bounds the HTTP call. The breaker counts *failures*, so a Vault that is slow but not yet erroring could stall a fetch without ever incrementing the count that would open it. Verified `hvac.Client` accepts `timeout` before relying on it.

## API-05 — the metric the CLI could never have matched

`aidlp stats` omitted `dlp_pii_detected_total`. It is emitted per type — `dlp_pii_detected_total{type="PERSON"} 3.0` — so the command's unlabelled `^name (\d+)` pattern was structurally incapable of matching it. Summing across labels needs its own pattern; verified against real `prometheus_client` output (3 + 2 → 5).

## API-06 — the metrics contract, completed

README's Observability section listed four metrics; the proxy exposes far more. It now lists all of them, grouped by purpose — traffic, term-source health, ML pool health — and says explicitly that `aidlp stats` surfaces only a subset.

## A mistake I made and caught

Documenting the new flag, I appended a second `dlp:` block to README's `config.yaml` example, producing a **duplicate key and invalid YAML**. Caught by parsing the example rather than eyeballing it; the block is now parsed as part of the check.

## Verification

| gate | result |
|---|---|
| `npm test` | **cannot run** — no root `package.json`; pre-existing |
| `python -m pytest -q` | **124 passed** (119 → 124) |
| `npm ci` + `npm run docs:build` | ok |

`flake8` clean at both the CI threshold and the stricter local `max-complexity=10`; `poetry check --lock` green.

## Still outstanding

The consolidated 75-finding brief remains truncated at finding 56 in both deliveries. Between it and these six follow-ups I have now seen **62 distinct IDs**; **13 remain unseen**. I cannot close what I cannot read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)